### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 4
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
It looks like a few tabs slipped in to Rust source. It's not worth trashing blame by fixing them, but let's add an editorconfig file to keep this from happening again.

cc @vmg 