### PR TITLE
errors: Fix write_colors macro

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -32,15 +32,9 @@ fn color_scheme(base: Color) -> (ColorSpec, ColorSpec, ColorSpec) {
 }
 
 macro_rules! write_color {
-    ($color:expr, $io:expr, $fmt:expr) => ({
+    ($color:expr, $io:expr, $($arg:tt)*) => ({
         $io.set_color(&$color)?;
-        write!($io, $fmt)?;
-        $io.reset()?;
-    });
-
-    ($color:expr, $io:expr, $fmt:expr, $($arg:expr),*) => ({
-        $io.set_color(&$color)?;
-        write!($io, $fmt, $($arg),*)?;
+        write!($io, $($arg)*)?;
         $io.reset()?;
     });
 }


### PR DESCRIPTION
I didn't know how to get optional varidic arguments working in the macro. Did some reading last night. This will also support named args when we need them. 👌 