### PR TITLE
Tuple -> Array instance degradation

### DIFF
--- a/src/typecheck/eval.rs
+++ b/src/typecheck/eval.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 use std::collections::HashMap;
 use typecheck::control::{Computation, ComputationPredicate, EvalResult};
 use typecheck::locals::{Locals, LocalEntry, LocalEntryMerge};
-use typecheck::types::{Arg, TypeEnv, Type, Prototype, KwsplatResult};
+use typecheck::types::{Arg, TypeEnv, Type, Prototype, KwsplatResult, TupleElement};
 use object::{Scope, RubyObject, MethodImpl};
 use ast::{Node, Loc, Id};
 use environment::Environment;
@@ -115,12 +115,6 @@ enum Lhs<'ty, 'object: 'ty> {
     Lvar(Loc, String),
     Simple(Loc, &'ty Type<'ty, 'object>),
     Send(Loc, &'ty Type<'ty, 'object>, Id, Vec<CallArg<'ty, 'object>>),
-}
-
-#[derive(Debug)]
-enum TupleElement<'ty, 'object: 'ty> {
-    Value(&'ty Type<'ty, 'object>),
-    Splat(&'ty Type<'ty, 'object>),
 }
 
 impl<'ty, 'env, 'object> Eval<'ty, 'env, 'object> {


### PR DESCRIPTION
This pull request implements type degradation for tuples into `Array` instances, similar to the current keyword hash -> `Hash` instance degradation.

This means that an expression such as `[1, "two"]` now has the type `[Integer, String]` rather than `[Integer | String]` as previously.

This tuple type will degrade into `[Integer | String]` when it needs to. This can happen in method calls or when the tuple is passed into a method expecting an instance type.

After degradation, the tuple type remains permanently degraded. This is because the degraded type is less specific than the tuple type and once invariants have been relaxed there's no guarantee that they still hold.