### PR TITLE
WIP: add some basic path checking

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -15,18 +15,6 @@ use object::{ObjectGraph, RubyObject, MethodEntry, Scope};
 use top_level;
 use typecheck;
 
-fn path_prefix_len(path: &Path, prefix: &Path) -> usize {
-    let mut a = path.components();
-    let mut b = prefix.components();
-    let mut len = 0;
-    loop {
-        match (a.next(), b.next()) {
-            (Some(ref x), Some(ref y)) if x == y => { len += 1 },
-            _ => return len,
-        }
-    }
-}
-
 enum LoadState {
     Loading,
     Loaded,
@@ -244,6 +232,13 @@ impl<'object> Environment<'object> {
     }
 
     pub fn resolve_module_root<'s>(&'s self, filename: &Path) -> Option<&'s Path> {
+        fn path_prefix_len(path: &Path, prefix: &Path) -> usize {
+            path.components()
+                .zip(prefix.components())
+                .take_while(|&(a, b)| a == b)
+                .count()
+        }
+
         let mut best_match: Option<&'s Path> = None;
         let mut best_len = 0;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,6 @@ extern crate typed_arena;
 extern crate termcolor;
 
 use std::path::PathBuf;
-use std::fs;
 use clap::{App, Arg};
 use typed_arena::Arena;
 use termcolor::{ColorChoice, StandardStream};
@@ -23,10 +22,10 @@ mod typecheck;
 mod util;
 
 use environment::Environment;
-use errors::ErrorReporter;
+use errors::{ErrorReporter, ErrorSink};
 use config::Config;
 
-fn config() -> (Config, Vec<PathBuf>) {
+fn config(report: &mut ErrorSink) -> (Config, Vec<PathBuf>) {
     let mut config = Config::new();
     let mut files = Vec::new();
 
@@ -67,27 +66,36 @@ fn config() -> (Config, Vec<PathBuf>) {
             .help("Source files to type check"))
         .get_matches();
 
-    if let Some(load_paths) = matches.values_of("load-path") {
-        config.require_paths.extend(load_paths.map(|p| {
-            PathBuf::from(p).canonicalize().unwrap()
-        }));
+    fn pathcheck(report: &mut ErrorSink, ptype: &str, paths: clap::Values) -> Vec<PathBuf> {
+        paths.filter_map(|path| {
+            let path = PathBuf::from(path);
+            match path.canonicalize() {
+                Ok(p) => Some(p),
+                Err(err) => {
+                    report.warning(
+                        &format!("missing {} path: '{}' ({})", ptype, path.display(), err),
+                        &vec![]
+                    );
+                    None
+                }
+            }
+        }).collect()
+    }
+
+    if let Some(require_paths) = matches.values_of("load-path") {
+        config.require_paths.extend(pathcheck(report, "require", require_paths));
     }
 
     if let Some(autoload_paths) = matches.values_of("autoload-path") {
-        config.autoload_paths.extend(autoload_paths.map(|p| {
-            PathBuf::from(p).canonicalize().unwrap()
-        }));
+        config.autoload_paths.extend(pathcheck(report, "autoload", autoload_paths));
+    }
+
+    if let Some(ignore_errors_in) = matches.values_of("ignore-errors-in") {
+        config.ignore_errors_in.extend(pathcheck(report, "ignore", ignore_errors_in));
     }
 
     if let Some(acronyms) = matches.values_of("inflect-acronym") {
         config.inflect_acronyms.extend(acronyms.map(String::from));
-    }
-
-    if let Some(ignore_errors_in) = matches.values_of("ignore-errors-in") {
-        config.ignore_errors_in.extend(ignore_errors_in
-            .map(PathBuf::from)
-            .map(fs::canonicalize)
-            .filter_map(Result::ok));
     }
 
     config.warning = matches.is_present("warning");
@@ -100,8 +108,9 @@ fn config() -> (Config, Vec<PathBuf>) {
 }
 
 fn main() {
-    let (config, files) = config();
-    let errors = ErrorReporter::new(StandardStream::stderr(ColorChoice::Auto));
+    let mut errors = ErrorReporter::new(StandardStream::stderr(ColorChoice::Auto));
+
+    let (config, files) = config(&mut errors);
     let arena = Arena::new();
     let env = Environment::new(&arena, Box::new(errors), config);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,11 +68,15 @@ fn config() -> (Config, Vec<PathBuf>) {
         .get_matches();
 
     if let Some(load_paths) = matches.values_of("load-path") {
-        config.require_paths.extend(load_paths.map(PathBuf::from));
+        config.require_paths.extend(load_paths.map(|p| {
+            PathBuf::from(p).canonicalize().unwrap()
+        }));
     }
 
     if let Some(autoload_paths) = matches.values_of("autoload-path") {
-        config.autoload_paths.extend(autoload_paths.map(PathBuf::from));
+        config.autoload_paths.extend(autoload_paths.map(|p| {
+            PathBuf::from(p).canonicalize().unwrap()
+        }));
     }
 
     if let Some(acronyms) = matches.values_of("inflect-acronym") {

--- a/src/top_level.rs
+++ b/src/top_level.rs
@@ -698,6 +698,9 @@ impl<'env, 'object> Eval<'env, 'object> {
 
                 match self.resolve_cbase(base) {
                     Ok(cbase) => {
+                        let path = self.env.object.constant_path(&cbase, name);
+                        self.check_constant_path(&path, &loc);
+
                         if let Some(constant_entry) = self.env.object.get_own_const(&cbase, name) {
                             self.constant_definition_error("Duplicate constant definition", &loc, &constant_entry.loc);
                             return;


### PR DESCRIPTION
As requested by @charliesome.

Given a file in `/home/vmg/src/typedruby/lib/typetest.rb`, with the following contents:

```rb
# @typedruby

module Foobar
  class Baz
    def valid?
      false
    end
  end
end

class TypeTest
  def valid?
    false
  end
end

class Typetest
  def valid?
    true
  end
end
```

It typechecks as follows:

```
~/src/typedruby vmg/paths .$ ./target/debug/typedruby lib/typetest.rb
error: constant defined outside of expected path

        @ /home/vmg/src/typedruby/lib/typetest.rb:3
      3 |  module Foobar
                  ^^^^^^ here

        - expected to be found at '/home/vmg/src/typedruby/lib/foobar.rb'


error: constant defined outside of expected path

        @ /home/vmg/src/typedruby/lib/typetest.rb:4
      4 |    class Baz
                   ^^^ here

        - expected to be found at '/home/vmg/src/typedruby/lib/foobar/baz.rb'


error: constant defined outside of expected path

        @ /home/vmg/src/typedruby/lib/typetest.rb:11
     11 |  class TypeTest
                 ^^^^^^^^ here

        - expected to be found at '/home/vmg/src/typedruby/lib/type_test.rb'
```

Is this completely bonkers? The thing I'm the most unsure about is `resolve_module_root`. I really think we need a function like that to be able to resolve Ruby paths properly -- the issue is that I'm rooting at `lib`, which doesn't cover 100% of the use cases of normal Ruby source.

Most notable, what happens for Rails code, which usually lives under `app`? How do we handle that?

I also asked you this, but to reiterate:

https://github.com/github/github/commit/6e29f7728de95d881234cdf491a8d941723c662b#diff-ac8daca08adcd64746d33c627f311bf4R10

>Is that a "valid" definition according to Rails autoloading?
> The file is `lib/github/pages/management/repair.rb`
> So clearly `GitHub::Pages::Management::Repair` is valid.
> But what about that nested `ReplicationInfo`?