### PR TITLE
Fix require path to stdlib definitions

### DIFF
--- a/gem/bin/typedruby
+++ b/gem/bin/typedruby
@@ -11,7 +11,7 @@ unless File.exist?(typedruby_bin)
   abort "Unsupported system: #{system}"
 end
 
-defs_path = File.expand_path("../definitions", __dir__)
+defs_path = File.expand_path("../definitions/lib", __dir__)
 
 exec [typedruby_bin, $0],
   "-I#{defs_path}",


### PR DESCRIPTION
The bin stub was passing the wrong path to the stdlib definitions to the typedruby binary. Easy fix.