### PR TITLE
Fix file extension logic in require resolution

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -160,10 +160,10 @@ impl<'object> Environment<'object> {
             .unwrap_or(false);
 
         let exts_for_file = if has_ext {
-            static NO_EXTS: &'static [&'static str] = &[""];
+            static NO_EXTS: &[&str] = &[""];
             NO_EXTS
         } else {
-            static REQUIRE_EXTS: &'static [&'static str] = &[".typed.rb", ".rb"];
+            static REQUIRE_EXTS: &[&str] = &[".typed.rb", ".rb"];
             REQUIRE_EXTS
         };
 


### PR DESCRIPTION
Ruby's require path resolution logic is sensitive to whether the argument passed to `require` has a file extension. Ruby will append `.rb` (or `.so`, `.bundle`, etc) if it doesn't, and treat the filename as verbatim if it does.

This fixes an issue where TypedRuby was incorrectly trying to load our `CODEOWNERS` file on a case insensitive filesystem when it encountered a require of the `codeowners` gem.