### PR TITLE
Fix dedenting binary data.

### DIFF
--- a/parser/src/builder.rs
+++ b/parser/src/builder.rs
@@ -130,7 +130,9 @@ impl Dedenter {
             result_bytes.drain(space_begin..space_end);
         }
 
-        String::from_utf8(result_bytes).unwrap()
+        unsafe {
+            String::from_utf8_unchecked(result_bytes)
+        }
     }
 
     fn interrupt(&mut self) {


### PR DESCRIPTION
Without this patch, `typedruby` panics on the test case:

```ruby
def hi
  <<~END.strip
    \x80
  END
end

```

While allowing the (semantically identical)

```ruby
def hi
  "\x80"
end
```

Constructing invalid utf-8 `String`s is likely to eventually lead to
sadness, so this suggests that a fuller fix is going to require
representing String literals as a `Vec<u8>`, maybe with an encoding
tag, instead. But that bug already exists in the latter test case, so
this commit should fix a panic without making the situation
fundamentally worse.