### PR TITLE
Special case $$

### DIFF
--- a/src/typecheck/eval.rs
+++ b/src/typecheck/eval.rs
@@ -2171,6 +2171,20 @@ impl<'ty, 'object> Eval<'ty, 'object> {
                     Computation::result(ty, l)
                 })
             }
+            Node::Gvar(ref loc, ref name) => {
+                let ty = match name.as_ref() {
+                    "$$" => self.tyenv.instance0(loc.clone(), self.env.object.Integer),
+                    _ => {
+                        self.error("Unknown global variable", &[
+                            Detail::Loc("here", loc),
+                        ]);
+
+                        self.tyenv.any(loc.clone())
+                    }
+                };
+
+                Computation::result(ty, locals)
+            }
             _ => panic!("node: {:?}", node),
         }
     }


### PR DESCRIPTION
I'm umming and ahhing about how TypedRuby should implement global variables.

We definitely need to support them to some extent - using `$$` and other built-in global variables is quite common in production Ruby code.

I don't know if we should support users declaring their own global variables though. It wouldn't be particularly difficult, but I don't know if we should encourage use of arbitrary globals by supporting them in TypedRuby.

I still haven't decided, so for now this pull request special cases `$$` and leaves the door open to special casing more built-in globals.