### PR TITLE
parser: Clamp line positions to EOF

### DIFF
--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -37,7 +37,7 @@ pub struct SourceLine {
 
 #[derive(Clone,Eq,PartialEq,Hash)]
 pub struct Loc {
-    pub file: Rc<SourceFile>,
+    file: Rc<SourceFile>,
     pub begin_pos: usize,
     pub end_pos: usize,
 }
@@ -85,6 +85,15 @@ impl fmt::Debug for Loc {
 }
 
 impl Loc {
+    pub fn new(file: Rc<SourceFile>, begin: usize, end: usize) -> Self {
+        let max = file.source.len();
+        Loc {
+            file: file,
+            begin_pos: min(max, begin),
+            end_pos: min(max, end),
+        }
+    }
+
     pub fn join(&self, other: &Loc) -> Loc {
         if self.file.filename != other.file.filename {
             panic!("can't join Locs of disparate files");
@@ -105,6 +114,10 @@ impl Loc {
         }
     }
 
+    pub fn file(&self) -> &Rc<SourceFile> {
+        &self.file
+    }
+
     pub fn begin(&self) -> Coords {
         self.coords_for_pos(self.begin_pos)
     }
@@ -115,11 +128,13 @@ impl Loc {
     }
 
     pub fn with_begin(&self, begin_pos: usize) -> Loc {
-        Loc { begin_pos, ..self.clone() }
+        let pos = min(begin_pos, self.file.source.len());
+        Loc { begin_pos: pos, ..self.clone() }
     }
 
     pub fn with_end(&self, end_pos: usize) -> Loc {
-        Loc { end_pos, ..self.clone() }
+        let pos = min(end_pos, self.file.source.len());
+        Loc { end_pos: pos, ..self.clone() }
     }
 }
 

--- a/parser/src/builder.rs
+++ b/parser/src/builder.rs
@@ -839,7 +839,7 @@ impl<'a> Builder<'a> {
     pub fn file_literal(&self, tok: Option<Token>) -> Node {
         if self.magic_literals {
             let loc = self.loc(&tok);
-            let filename = loc.file.filename().to_str().unwrap();
+            let filename = loc.file().filename().to_str().unwrap();
             Node::String(loc.clone(), RubyString::new(filename.as_bytes()))
         } else {
             Node::FileLiteral(self.loc(&tok))
@@ -990,8 +990,8 @@ impl<'a> Builder<'a> {
     pub fn line_literal(&self, tok: Option<Token>) -> Node {
         if self.magic_literals {
             let loc = self.loc(&tok);
-            let line = loc.file.line_for_pos(loc.begin_pos);
-            Node::Integer(loc.clone(), line.number.to_string())
+            let line = loc.begin().line;
+            Node::Integer(loc.clone(), line.to_string())
         } else {
             Node::LineLiteral(self.loc(&tok))
         }

--- a/parser/src/ffi.rs
+++ b/parser/src/ffi.rs
@@ -125,12 +125,7 @@ impl Token {
     pub fn location(&self, file: Rc<SourceFile>) -> Loc {
         let begin = unsafe { rbtoken_get_start(self.token) };
         let end = unsafe { rbtoken_get_end(self.token) };
-
-        Loc {
-            file: file,
-            begin_pos: begin,
-            end_pos: end,
-        }
+        Loc::new(file, begin, end)
     }
 
     pub fn string(&self) -> String {
@@ -239,12 +234,7 @@ impl Driver {
                 diag
             };
 
-            let loc = Loc {
-                file: self.current_file.clone(),
-                begin_pos: cdiag.begin_pos,
-                end_pos: cdiag.end_pos
-            };
-
+            let loc = Loc::new(self.current_file.clone(), cdiag.begin_pos, cdiag.end_pos);
             let cstr = unsafe { CStr::from_ptr(cdiag.data) }.to_str();
             let data = match cstr {
                 Ok(msg) => if msg.len() > 0 { Some(msg.to_owned()) } else { None },

--- a/parser/tests/whitequark_diags.rs
+++ b/parser/tests/whitequark_diags.rs
@@ -457,3 +457,9 @@ fn diag_send_block_blockarg() {
 	assert_diag!(code, Level::Error, Error::BlockAndBlockarg, OPTIONS);
 }
 
+#[test]
+fn diag_missing_end() {
+	let code = "def foobar";
+	assert_diag!(code, Level::Error, Error::UnexpectedToken, OPTIONS);
+}
+

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -71,27 +71,25 @@ impl<T: WriteColor> ErrorReporter<T> {
         for detail in details {
             match *detail {
                 Detail::Loc(ref message, ref loc) => {
-                    let begin = loc.file.line_for_pos(loc.begin_pos);
-                    let end = loc.file.line_for_pos(loc.end_pos);
+                    let begin = loc.file().line_for_pos(loc.begin_pos);
+                    let end = loc.file().line_for_pos(loc.end_pos);
 
                     write_color!(low, self.io, "        @ {}:{}\n",
-                        loc.file.filename().display(),
+                        loc.file().filename().display(),
                         begin.number);
 
                     if begin.number == end.number {
                         // same line
                         let line_info = begin;
+                        let source = loc.file().source();
 
                         write_color!(low, self.io, "{:>7} | ", line_info.number);
 
-                        write!(self.io, " {}",
-                               &loc.file.source()[line_info.begin_pos..loc.begin_pos])?;
+                        write!(self.io, " {}", &source[line_info.begin_pos..loc.begin_pos])?;
 
-                        write_color!(err, self.io, "{}",
-                                     &loc.file.source()[loc.begin_pos..loc.end_pos]);
+                        write_color!(err, self.io, "{}", &source[loc.begin_pos..loc.end_pos]);
 
-                        write!(self.io, "{}\n",
-                               &loc.file.source()[loc.end_pos..line_info.end_pos].trim_right())?;
+                        write!(self.io, "{}\n", source[loc.end_pos..line_info.end_pos].trim_right())?;
 
                         write_color!(err, self.io, "{0:1$}{2}",
                            "", 11 + loc.begin_pos - line_info.begin_pos,
@@ -100,7 +98,7 @@ impl<T: WriteColor> ErrorReporter<T> {
 
                         write_color!(high, self.io, " {}\n", message);
                     } else {
-                        let source = loc.file.source()[begin.begin_pos..end.end_pos].split("\n");
+                        let source = loc.file().source()[begin.begin_pos..end.end_pos].split("\n");
 
                         write_color!(err, self.io, "{0:1$}{2}v\n",
                             "", 10, "-".repeat(loc.begin_pos - begin.begin_pos + 1)

--- a/src/top_level.rs
+++ b/src/top_level.rs
@@ -495,7 +495,7 @@ impl<'env, 'object> Eval<'env, 'object> {
         if let Some(pathstr) = string.string() {
             let path = match require_type {
                 RequireType::LoadPath => self.env.search_require_path(&pathstr),
-                RequireType::Relative => self.env.search_relative_path(&pathstr, &args[0].loc().file),
+                RequireType::Relative => self.env.search_relative_path(&pathstr, &args[0].loc().file()),
             };
 
             if let Some(path) = path {
@@ -984,9 +984,7 @@ fn source_type_for_file(source_file: &SourceFile) -> SourceType {
 
 pub fn evaluate<'env, 'object: 'env>(env: &'env Environment<'object>, node: Rc<Node>) {
     let scope = Rc::new(Scope { parent: None, module: env.object.Object });
-
-    let source_file = node.loc().file.clone();
-
+    let source_file = node.loc().file().clone();
     let source_type = source_type_for_file(&source_file);
 
     Eval::new(env, scope, source_file, source_type, false).eval_node(&node);

--- a/src/typecheck/eval.rs
+++ b/src/typecheck/eval.rs
@@ -1541,12 +1541,7 @@ impl<'ty, 'object> Eval<'ty, 'object> {
                 }
             }
             Node::Yield(ref loc, ref args) => {
-                let invoc_loc = Loc {
-                    file: loc.file.clone(),
-                    begin_pos: loc.begin_pos,
-                    end_pos: loc.begin_pos + 5,
-                };
-
+                let invoc_loc = loc.with_end(loc.begin_pos + 5);
                 self.process_yield(loc, &invoc_loc, args, locals)
             }
             Node::Hash(ref loc, ref pairs) => {


### PR DESCRIPTION
Prevent out-of-bounds reads by clamping all positions to the size of the current file.

In order to ensure `Loc` values are always valid, the `file` field has been made private. This enforces the usage of the `Loc::new` constructor.

cc @charliesome 