### PR TITLE
.editorconfig tweaks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,9 @@ indent_style = space
 [*.{rs,cc,hh}]
 indent_size = 4
 
+[*.{rl,ypp}]
+indent_size = 2
+
 [*.{rb,gemspec}]
 indent_size = 2
 


### PR DESCRIPTION
This pull request tweaks our `.editorconfig` a little bit.

Ruby files were unintentionally caught in the previous config and forced to 4 space indentation, which isn't what we want.

I've also set `.rl` and `.ypp` files to 2 space indentation here. Ideally they'd be 4 spaces like the rest of our C++ and Rust code, but they're already 2 spaces and it's not worth ruining the blame to reindent them.