### PR TITLE
Use polymorphic Enumerable module in Set

### DIFF
--- a/definitions/lib/set.rb
+++ b/definitions/lib/set.rb
@@ -7,13 +7,13 @@ class Set::[ElementType]
 
   def <<(ElementType element) => :self; end
 
-  def +((Set::[ElementType] | Array::[ElementType]) other) => :self; end
+  def +(Enumerable::[ElementType] other) => :self; end
 
   def include?(ElementType element) => Boolean; end
 
-  def |((Set::[ElementType] | Array::[ElementType]) other) => :self; end
+  def |(Enumerable::[ElementType] other) => :self; end
 
-  def &((Set::[ElementType] | Array::[ElementType]) other) => :self; end
+  def &(Enumerable::[ElementType] other) => :self; end
 
   def to_a => [ElementType]; end
 end


### PR DESCRIPTION
This updates the stdlib `Set` implementation to use polymorphic `Enumerable` now that we have support for that!