### PR TITLE
Add/Improve some string-related signatures

### DIFF
--- a/definitions/core.rb
+++ b/definitions/core.rb
@@ -727,13 +727,15 @@ class String < Object
 
   def *(Integer times) => String; end
 
-  def sub((String | Regexp) pattern, { |String s| => String } &) => String; end
+  # Ideally these would be overloaded to allow exactly one of `repl`
+  # and a block, but we don't support overloads.
+  def sub((String | Regexp) pattern, ~String repl=nil, ~{ |String s| => String } &) => String; end
 
-  def gsub((String | Regexp) pattern, { |String s| => String } &) => String; end
+  def gsub((String | Regexp) pattern, ~String repl=nil, ~{ |String s| => String } &) => String; end
 
-  def sub!((String | Regexp) pattern, { |String s| => String } &) => ~String; end
+  def sub!((String | Regexp) pattern, ~String repl=nil, ~{ |String s| => String } &) => ~String; end
 
-  def gsub!((String | Regexp) pattern, { |String s| => String } &) => ~String; end
+  def gsub!((String | Regexp) pattern, ~String repl=nil, ~{ |String s| => String } &) => ~String; end
 
   def size => Integer; end
 

--- a/tests/fixtures/constrained_core_methods.out
+++ b/tests/fixtures/constrained_core_methods.out
@@ -3,8 +3,8 @@ error: Could not match types:
         @ __ROOT__/tests/fixtures/constrained_core_methods.rb:3
       3 |  def array_compact => nil
                                 ^^^ NilClass, with:
-        @ (builtin stdlib):827
-    827 |    def compact[NonNullType; ~NonNullType = ElementType] => [NonNullType]; end
+        @ (builtin stdlib):829
+    829 |    def compact[NonNullType; ~NonNullType = ElementType] => [NonNullType]; end
                                                                      ^^^^^^^^^^^^^ Array::[Integer]
 
         - arising from an attempt to match:
@@ -18,8 +18,8 @@ error: Could not match types:
 
 error: Could not match types:
 
-        @ (builtin stdlib):827
-    827 |    def compact[NonNullType; ~NonNullType = ElementType] => [NonNullType]; end
+        @ (builtin stdlib):829
+    829 |    def compact[NonNullType; ~NonNullType = ElementType] => [NonNullType]; end
                                       ^^^^^^^^^^^^ NilClass | t2, with:
         @ __ROOT__/tests/fixtures/constrained_core_methods.rb:8
       8 |    [1, 2, 3].compact
@@ -27,14 +27,14 @@ error: Could not match types:
 
         - arising from an attempt to match:
 
-        @ (builtin stdlib):827
-    827 |    def compact[NonNullType; ~NonNullType = ElementType] => [NonNullType]; end
+        @ (builtin stdlib):829
+    829 |    def compact[NonNullType; ~NonNullType = ElementType] => [NonNullType]; end
                                       ^^^^^^^^^^^^ NilClass | t2, with:
-        @ (builtin stdlib):827
-    827 |    def compact[NonNullType; ~NonNullType = ElementType] => [NonNullType]; end
+        @ (builtin stdlib):829
+    829 |    def compact[NonNullType; ~NonNullType = ElementType] => [NonNullType]; end
                                                      ^^^^^^^^^^^ Integer
-        @ (builtin stdlib):827
-    827 |    def compact[NonNullType; ~NonNullType = ElementType] => [NonNullType]; end
+        @ (builtin stdlib):829
+    829 |    def compact[NonNullType; ~NonNullType = ElementType] => [NonNullType]; end
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^ in this expression
 
 error: Could not match types:
@@ -42,8 +42,8 @@ error: Could not match types:
         @ __ROOT__/tests/fixtures/constrained_core_methods.rb:11
      11 |  def array_to_h => nil
                              ^^^ NilClass, with:
-        @ (builtin stdlib):841
-    841 |    def to_h[K, V; ElementType = [K, V]] => { K => V }; end
+        @ (builtin stdlib):843
+    843 |    def to_h[K, V; ElementType = [K, V]] => { K => V }; end
                                                      ^^^^^^^^^^ Hash::[String, Integer]
 
         - arising from an attempt to match:
@@ -60,18 +60,18 @@ error: Could not match types:
         @ __ROOT__/tests/fixtures/constrained_core_methods.rb:16
      16 |    [["one", 1], 2].to_h
              ^^^^^^^^^^^^^^^ [String, Integer] | Integer, with:
-        @ (builtin stdlib):841
-    841 |    def to_h[K, V; ElementType = [K, V]] => { K => V }; end
+        @ (builtin stdlib):843
+    843 |    def to_h[K, V; ElementType = [K, V]] => { K => V }; end
                                           ^^^^^^ [t3, t4]
 
         - arising from an attempt to match:
 
-        @ (builtin stdlib):841
-    841 |    def to_h[K, V; ElementType = [K, V]] => { K => V }; end
+        @ (builtin stdlib):843
+    843 |    def to_h[K, V; ElementType = [K, V]] => { K => V }; end
                             ^^^^^^^^^^^ [String, Integer] | Integer, with:
-        @ (builtin stdlib):841
-    841 |    def to_h[K, V; ElementType = [K, V]] => { K => V }; end
+        @ (builtin stdlib):843
+    843 |    def to_h[K, V; ElementType = [K, V]] => { K => V }; end
                                           ^^^^^^ [t3, t4]
-        @ (builtin stdlib):841
-    841 |    def to_h[K, V; ElementType = [K, V]] => { K => V }; end
+        @ (builtin stdlib):843
+    843 |    def to_h[K, V; ElementType = [K, V]] => { K => V }; end
                             ^^^^^^^^^^^^^^^^^^^^ in this expression

--- a/tests/fixtures/module_compatibility.out
+++ b/tests/fixtures/module_compatibility.out
@@ -24,8 +24,8 @@ error: Could not match types:
         @ __ROOT__/tests/fixtures/module_compatibility.rb:24
      24 |    set = MySet.new([1, 2, 3])
                               ^ Integer, with:
-        @ (builtin stdlib):852
-    852 |    include Enumerable::[[KeyType, ValueType]]
+        @ (builtin stdlib):854
+    854 |    include Enumerable::[[KeyType, ValueType]]
                                   ^^^^^^^^^^^^^^^^^^^^ Array::[Integer]
 
         - arising from an attempt to match:

--- a/tests/fixtures/module_reinclusion.out
+++ b/tests/fixtures/module_reinclusion.out
@@ -3,8 +3,8 @@ error: Duplicate include
         @ __ROOT__/tests/fixtures/module_reinclusion.rb:4
       4 |    include Enumerable::[Integer]
                      ^^^^^^^^^^^^^^^^^^^^^ here
-        @ (builtin stdlib):784
-    784 |    include Enumerable::[ElementType]
+        @ (builtin stdlib):786
+    786 |    include Enumerable::[ElementType]
                      ^^^^^^^^^^^^^^^^^^^^^^^^^ previous inclusion was here
 
 error: Duplicate include

--- a/tests/fixtures/recursive_type.out
+++ b/tests/fixtures/recursive_type.out
@@ -9,8 +9,8 @@ error: Could not match types:
 
         - arising from an attempt to match:
 
-        @ (builtin stdlib):788
-    788 |    def <<(ElementType item) => :self; end
+        @ (builtin stdlib):790
+    790 |    def <<(ElementType item) => :self; end
                     ^^^^^^^^^^^ t1, with:
         @ __ROOT__/tests/fixtures/recursive_type.rb:6
       6 |    a << a

--- a/tests/fixtures/type_parameter_mismatch.out
+++ b/tests/fixtures/type_parameter_mismatch.out
@@ -12,6 +12,6 @@ error: Mismatched type parameters
         @ __ROOT__/tests/fixtures/type_parameter_mismatch.rb:4
       4 |  class Array::[Nope]
                  ^^^^^^^^^^^^^ here
-        @ (builtin stdlib):783
-    783 |  class Array::[ElementType] < Object
+        @ (builtin stdlib):785
+    785 |  class Array::[ElementType] < Object
                  ^^^^^^^^^^^^^^^^^^^^ previous definition here


### PR DESCRIPTION
In ways that came up when typing some Stripe code.

ec02755 is probably the only controversial choice; It seems likely we'll need, at a minimum, some kind of special-case overloading for stdlib methods, but allowing more real code through feels like the right tradeoff for now.

https://github.com/search?utf8=%E2%9C%93&q=gsub+extension%3Arb&type=Code

shows that `gsub(String, String)` and `gsub(Regex, String)`  in particular are quite common.