### PR TITLE
Comment-based type annotations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,9 @@ name = "ruby_parser"
 version = "0.1.0"
 dependencies = [
  "cc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -44,7 +44,7 @@ cc = "1.0"
 
 [features]
 default = []
-regex = ["onig"]
+ruby_regexp = ["onig"]
 
 [dev-dependencies]
 glob = "0.2"

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -37,6 +37,8 @@ include = [
 
 [dependencies]
 libc = "0.2.0"
+regex = "0.2"
+lazy_static = "0.2"
 onig = { version = "1.2", optional = true }
 
 [build-dependencies]

--- a/parser/cc/capi.cc
+++ b/parser/cc/capi.cc
@@ -2,10 +2,11 @@
 #include <cstdio>
 
 ruby_parser::typedruby24*
-rbdriver_typedruby24_new(const char* source_ptr, size_t source_length, const ruby_parser::builder* builder)
+rbdriver_typedruby24_new(ruby_parser::parser_mode mode, const char* source_ptr, size_t source_length, const ruby_parser::builder* builder)
 {
 	std::string source { source_ptr, source_length };
-	return new ruby_parser::typedruby24(source, *builder);
+
+	return new ruby_parser::typedruby24(mode, source, *builder);
 }
 
 void

--- a/parser/cc/capi.cc
+++ b/parser/cc/capi.cc
@@ -99,3 +99,31 @@ rbdriver_diag_report(ruby_parser::base_driver* driver, const struct cdiagnostic 
 		diag->data ? std::string(diag->data) : ""
 	);
 }
+
+size_t
+rbdriver_comment_get_length(const ruby_parser::base_driver* parser)
+{
+    return parser->lex.comments.size();
+}
+
+size_t
+rbdriver_comment_get_begin(const ruby_parser::base_driver* parser, size_t index)
+{
+    return parser->lex.comments.at(index).begin_pos();
+}
+
+size_t
+rbdriver_comment_get_end(const ruby_parser::base_driver* parser, size_t index)
+{
+    return parser->lex.comments.at(index).end_pos();
+}
+
+size_t
+rbdriver_comment_get_string(const ruby_parser::base_driver* parser, size_t index, const char** out_ptr)
+{
+    auto &comment = parser->lex.comments.at(index);
+
+    *out_ptr = comment.string().data();
+
+    return comment.string().size();
+}

--- a/parser/cc/driver.cc
+++ b/parser/cc/driver.cc
@@ -6,8 +6,10 @@
 
 namespace ruby_parser {
 
-base_driver::base_driver(ruby_version version, const std::string& source, const struct builder& builder)
-	: build(builder),
+base_driver::base_driver(ruby_version version, parser_mode mode, const std::string& source, const struct builder& builder)
+	: mode(mode),
+	emitted_mode_pseudotoken(false),
+	build(builder),
 	lex(diagnostics, version, source),
 	pending_error(false),
 	def_level(0),
@@ -15,8 +17,8 @@ base_driver::base_driver(ruby_version version, const std::string& source, const 
 {
 }
 
-typedruby24::typedruby24(const std::string& source, const struct builder& builder)
-	: base_driver(ruby_version::RUBY_24, source, builder)
+typedruby24::typedruby24(parser_mode mode, const std::string& source, const struct builder& builder)
+	: base_driver(ruby_version::RUBY_24, mode, source, builder)
 {}
 
 foreign_ptr typedruby24::parse(self_ptr self) {

--- a/parser/cc/grammars/typedruby24.ypp
+++ b/parser/cc/grammars/typedruby24.ypp
@@ -398,17 +398,17 @@ namespace bison {
 namespace typedruby24 {
 
 #define DIAGCHECK() do { \
-	if (driver.pending_error) { \
-		driver.pending_error = false; \
-		YYERROR; \
-	} \
+        if (driver.pending_error) { \
+                driver.pending_error = false; \
+                YYERROR; \
+        } \
 } while(false);
 
 void parser::error(const std::string &msg) {
-	driver.diagnostics.emplace_back(
-		dlevel::ERROR, dclass::UnexpectedToken,
-		diagnostic::range(driver.lex.last_token_s, driver.lex.last_token_e),
-		msg);
+        driver.diagnostics.emplace_back(
+                dlevel::ERROR, dclass::UnexpectedToken,
+                diagnostic::range(driver.lex.last_token_s, driver.lex.last_token_e),
+                msg);
 }
 
 int yylex(parser::semantic_type *lval, ruby_parser::typedruby24 &driver) {
@@ -465,14 +465,14 @@ int yylex(parser::semantic_type *lval, ruby_parser::typedruby24 &driver) {
 
                       if (rescue_bodies->size() == 0 && else_ != nullptr) {
                         driver.diagnostics.emplace_back(
-			  dlevel::WARNING, dclass::UselessElse, else_->tok);
+                          dlevel::WARNING, dclass::UselessElse, else_->tok);
                       }
 
                       $$ = driver.build.begin_body(self, $1, rescue_bodies,
-						else_ ? else_->tok : nullptr,
-						else_ ? else_->nod : nullptr,
-						ensure ? ensure->tok : nullptr,
-						ensure ? ensure->nod : nullptr);
+                                                else_ ? else_->tok : nullptr,
+                                                else_ ? else_->nod : nullptr,
+                                                ensure ? ensure->tok : nullptr,
+                                                ensure ? ensure->nod : nullptr);
                     }
 
         compstmt: stmts opt_terms
@@ -502,7 +502,7 @@ int yylex(parser::semantic_type *lval, ruby_parser::typedruby24 &driver) {
                 | klBEGIN tLCURLY top_compstmt tRCURLY
                     {
                       driver.diagnostics.emplace_back(dlevel::ERROR,
-			dclass::BeginInMethod, $1);
+                        dclass::BeginInMethod, $1);
                       YYERROR;
                     }
 
@@ -550,7 +550,7 @@ int yylex(parser::semantic_type *lval, ruby_parser::typedruby24 &driver) {
                 | stmt kRESCUE_MOD stmt
                     {
                       ruby_parser::node_list rescue_body(
-						driver.build.rescue_body(self, $2, nullptr, nullptr, nullptr, nullptr, $3));
+                                                driver.build.rescue_body(self, $2, nullptr, nullptr, nullptr, nullptr, $3));
                       $$ = driver.build.begin_body(self, $1, &rescue_body, nullptr, nullptr, nullptr, nullptr);
                     }
                 | klEND tLCURLY compstmt tRCURLY
@@ -621,7 +621,7 @@ int yylex(parser::semantic_type *lval, ruby_parser::typedruby24 &driver) {
                 | command_call kRESCUE_MOD stmt
                     {
                       node_list rescue_body(
-			driver.build.rescue_body(self, $2, nullptr, nullptr, nullptr, nullptr, $3));
+                        driver.build.rescue_body(self, $2, nullptr, nullptr, nullptr, nullptr, $3));
                       $$ = driver.build.begin_body(self, $1, &rescue_body, nullptr, nullptr, nullptr, nullptr);
                     }
                 | command_asgn
@@ -1453,15 +1453,15 @@ int yylex(parser::semantic_type *lval, ruby_parser::typedruby24 &driver) {
                     {
                       auto &else_ = $5;
                       $$ = driver.build.condition(self, $1, $2, $3, $4,
-			else_ ? else_->tok : nullptr,
-			else_ ? else_->nod : nullptr, $6);
+                        else_ ? else_->tok : nullptr,
+                        else_ ? else_->nod : nullptr, $6);
                     }
                 | kUNLESS expr_value then compstmt opt_else kEND
                     {
                       auto &else_ = $5;
                       $$ = driver.build.condition(self, $1, $2, $3,
                         else_ ? else_->nod : nullptr,
-			else_ ? else_->tok : nullptr, $4, $6);
+                        else_ ? else_->tok : nullptr, $4, $6);
                     }
                 | kWHILE
                     {
@@ -1494,7 +1494,7 @@ int yylex(parser::semantic_type *lval, ruby_parser::typedruby24 &driver) {
                       $$ = driver.build.case_(self, $1, $2,
                         &case_body->whens,
                         else_ ? else_->tok : nullptr,
-			else_ ? else_->nod : nullptr, $5);
+                        else_ ? else_->nod : nullptr, $5);
                     }
                 | kCASE opt_terms case_body kEND
                     {
@@ -1503,7 +1503,7 @@ int yylex(parser::semantic_type *lval, ruby_parser::typedruby24 &driver) {
                       $$ = driver.build.case_(self, $1, nullptr,
                         &case_body->whens,
                         else_ ? else_->tok : nullptr,
-			else_ ? else_->nod : nullptr, $4);
+                        else_ ? else_->nod : nullptr, $4);
                     }
                 | kFOR for_var kIN
                     {
@@ -2165,9 +2165,9 @@ opt_block_args_tail:
 
                       rescues->push_front(driver.build.rescue_body(self, $1,
                           exc_list,
-			  exc_var ? exc_var->tok : nullptr,
-			  exc_var ? exc_var->nod : nullptr,
-			  $4, $5));
+                          exc_var ? exc_var->tok : nullptr,
+                          exc_var ? exc_var->nod : nullptr,
+                          $4, $5));
 
                       $$ = rescues;
                     }

--- a/parser/cc/grammars/typedruby24.ypp
+++ b/parser/cc/grammars/typedruby24.ypp
@@ -451,9 +451,14 @@ int yylex(parser::semantic_type *lval, ruby_parser::typedruby24 &driver) {
                     {
                       driver.ast = $2;
                     }
-                | modePROTOTYPE f_arglist
+                | modePROTOTYPE
                     {
-                      driver.ast = $2;
+                      driver.lex.set_state_expr_endfn();
+                      driver.lex.cmdarg.clear();
+                    }
+                  f_arglist
+                    {
+                      driver.ast = $3;
                     }
 
          program: top_compstmt

--- a/parser/cc/grammars/typedruby24.ypp
+++ b/parser/cc/grammars/typedruby24.ypp
@@ -32,6 +32,8 @@ using namespace std::string_literals;
 // if any of these token values are changed here, the header must be updated
 // as well.
 %token <token>
+  modePROGRAM            1
+  modePROTOTYPE          2
   kCLASS              1001
   kMODULE             1002
   kDEF                1003
@@ -223,6 +225,7 @@ using namespace std::string_literals;
   opt_block_param
   primary
   primary_value
+  program
   qsymbols
   qwords
   regexp
@@ -412,20 +415,50 @@ void parser::error(const std::string &msg) {
 }
 
 int yylex(parser::semantic_type *lval, ruby_parser::typedruby24 &driver) {
-	auto token = driver.lex.advance();
-	int token_type = static_cast<int>(token->type());
-	assert(token_type >= 0);
-	lval->token = token;
-	return token_type;
+  token_t token = nullptr;
+
+  if (driver.emitted_mode_pseudotoken) {
+    token = driver.lex.advance();
+  } else {
+    driver.emitted_mode_pseudotoken = true;
+
+    ruby_parser::token_type token_type;
+    switch (driver.mode) {
+      case parser_mode::PROGRAM:
+        token_type = ruby_parser::token_type::modePROGRAM;
+        break;
+      case parser_mode::PROTOTYPE:
+        token_type = ruby_parser::token_type::modePROTOTYPE;
+        break;
+      default:
+        abort();
+    }
+
+    token = driver.lex.alloc_token(token_type, 0, 0, "");
+  }
+
+  int token_type = static_cast<int>(token->type());
+  assert(token_type >= 0);
+  lval->token = token;
+  return token_type;
 }
 
 }}} // namespace
 } // %code
 
 %%
+           start: modePROGRAM program
+                    {
+                      driver.ast = $2;
+                    }
+                | modePROTOTYPE f_arglist
+                    {
+                      driver.ast = $2;
+                    }
+
          program: top_compstmt
                     {
-                      driver.ast = $1;
+                      $$ = $1;
                     }
 
     top_compstmt: top_stmts opt_terms

--- a/parser/cc/grammars/typedruby24.ypp
+++ b/parser/cc/grammars/typedruby24.ypp
@@ -456,7 +456,7 @@ int yylex(parser::semantic_type *lval, ruby_parser::typedruby24 &driver) {
                       driver.lex.set_state_expr_endfn();
                       driver.lex.cmdarg.clear();
                     }
-                  f_arglist
+                  f_arglist opt_terms
                     {
                       driver.ast = $3;
                     }

--- a/parser/cc/lexer.rl
+++ b/parser/cc/lexer.rl
@@ -605,6 +605,10 @@ void lexer::set_state_expr_beg() {
   cs = lex_en_expr_beg;
 }
 
+void lexer::set_state_expr_endfn() {
+  cs = lex_en_expr_endfn;
+}
+
 void lexer::set_state_expr_endarg() {
   cs = lex_en_expr_endarg;
 }

--- a/parser/cc/lexer.rl
+++ b/parser/cc/lexer.rl
@@ -172,9 +172,10 @@ int lexer::arg_or_cmdarg() {
 }
 
 void lexer::emit_comment(const char* s, const char* e) {
-  /* unused for now */
-  (void)s;
-  (void)e;
+  size_t offset_start = (size_t)(s - source_buffer.data());
+  size_t offset_end = (size_t)(e - source_buffer.data());
+
+  comments.emplace_back(offset_start, offset_end, tok(s, e));
 }
 
 std::string lexer::tok() {
@@ -2606,4 +2607,20 @@ optional_size lexer::dedent_level() {
   auto ret = dedent_level_;
   dedent_level_ = std::nullopt;
   return ret;
+}
+
+comment::comment(size_t begin_pos, size_t end_pos, std::string string)
+  : begin_pos_(begin_pos), end_pos_(end_pos), string_(string)
+{}
+
+size_t comment::begin_pos() const {
+  return begin_pos_;
+}
+
+size_t comment::end_pos() const {
+  return end_pos_;
+}
+
+const std::string& comment::string() const {
+  return string_;
 }

--- a/parser/codegen/builder.rb
+++ b/parser/codegen/builder.rb
@@ -2,9 +2,6 @@
 
 require 'optparse'
 
-RE_BODY = /struct builder \{(.*?)\}/m
-RE_FUNC = /foreign_ptr\(\*(\w+)\)\((.*?)\);/
-
 CHECK_COOKIES = false
 TYPE_CONVERSION = {
   "foreign_ptr" => "NodeId",
@@ -107,13 +104,13 @@ end
 
 def get_definitions(filename)
   cpp = File.read(filename)
-  builder = RE_BODY.match(cpp)
+  builder = /struct builder \{(.*?)\}/m.match(cpp)
 
   abort("failed to match 'struct builder' body in #{filename}") unless builder
   defs = builder[1].split("\n").map { |d| d.strip }.reject { |d| d.empty? }
 
   defs.map do |d|
-    match = RE_FUNC.match(d)
+    match = /foreign_ptr\(\*(\w+)\)\((.*?)\);/.match(d)
     abort("bad definition: '#{d}'") unless match
     method, args = match[1], match[2]
 

--- a/parser/include/ruby_parser/capi.hh
+++ b/parser/include/ruby_parser/capi.hh
@@ -17,7 +17,7 @@ struct cdiagnostic {
 };
 
 ruby_parser::typedruby24*
-rbdriver_typedruby24_new(const char* source, size_t source_length, const ruby_parser::builder* builder);
+rbdriver_typedruby24_new(ruby_parser::parser_mode mode, const char* source, size_t source_length, const ruby_parser::builder* builder);
 
 void
 rbdriver_typedruby24_free(ruby_parser::typedruby24* parser);

--- a/parser/include/ruby_parser/capi.hh
+++ b/parser/include/ruby_parser/capi.hh
@@ -58,6 +58,18 @@ rbdriver_diag_get(const ruby_parser::base_driver* parser, size_t index, struct c
 void
 rbdriver_diag_report(ruby_parser::base_driver* driver, const struct cdiagnostic *diag);
 
+size_t
+rbdriver_comment_get_length(const ruby_parser::base_driver* parser);
+
+size_t
+rbdriver_comment_get_begin(const ruby_parser::base_driver* parser, size_t index);
+
+size_t
+rbdriver_comment_get_end(const ruby_parser::base_driver* parser, size_t index);
+
+size_t
+rbdriver_comment_get_string(const ruby_parser::base_driver* parser, size_t index, const char** out_ptr);
+
 }
 
 #endif

--- a/parser/include/ruby_parser/driver.hh
+++ b/parser/include/ruby_parser/driver.hh
@@ -123,8 +123,15 @@ public:
 	}
 };
 
+enum class parser_mode : int {
+	PROGRAM = 1,
+	PROTOTYPE = 2,
+};
+
 class base_driver {
 public:
+	parser_mode mode;
+	bool emitted_mode_pseudotoken;
 	diagnostics_t diagnostics;
 	const builder& build;
 	lexer lex;
@@ -134,7 +141,7 @@ public:
 	size_t def_level;
 	foreign_ptr ast;
 
-	base_driver(ruby_version version, const std::string& source, const struct builder& builder);
+	base_driver(ruby_version version, parser_mode mode, const std::string& source, const struct builder& builder);
 	virtual ~base_driver() {}
 	virtual foreign_ptr parse(self_ptr self) = 0;
 
@@ -161,7 +168,7 @@ public:
 
 class typedruby24 : public base_driver {
 public:
-	typedruby24(const std::string& source, const struct builder& builder);
+	typedruby24(parser_mode mode, const std::string& source, const struct builder& builder);
 	virtual foreign_ptr parse(self_ptr self);
 	~typedruby24() {}
 };

--- a/parser/include/ruby_parser/lexer.hh
+++ b/parser/include/ruby_parser/lexer.hh
@@ -26,6 +26,19 @@ namespace ruby_parser {
     RUBY_24,
   };
 
+  class comment {
+    size_t begin_pos_;
+    size_t end_pos_;
+    std::string string_;
+
+  public:
+    size_t begin_pos() const;
+    size_t end_pos() const;
+    const std::string& string() const;
+
+    comment(size_t begin_pos, size_t end_pos, std::string string);
+  };
+
   class lexer {
   public:
     using environment = std::set<std::string>;
@@ -130,6 +143,8 @@ namespace ruby_parser {
     size_t last_token_e;
 
     bool in_kwarg;            // true at the end of "def foo a:"
+
+    std::vector<comment> comments;
 
     lexer(diagnostics_t &diag, ruby_version version, const std::string& source_buffer_);
 

--- a/parser/include/ruby_parser/lexer.hh
+++ b/parser/include/ruby_parser/lexer.hh
@@ -162,6 +162,11 @@ namespace ruby_parser {
     bool is_declared(const std::string& identifier) const;
 
     optional_size dedent_level();
+
+    template<typename... Args>
+    decltype(auto) alloc_token(Args&&... args) {
+      return mempool.alloc(std::forward<Args>(args)...);
+    }
   };
 }
 

--- a/parser/include/ruby_parser/lexer.hh
+++ b/parser/include/ruby_parser/lexer.hh
@@ -151,6 +151,7 @@ namespace ruby_parser {
     token_t advance();
 
     void set_state_expr_beg();
+    void set_state_expr_endfn();
     void set_state_expr_endarg();
     void set_state_expr_fname();
     void set_state_expr_value();

--- a/parser/include/ruby_parser/token.hh
+++ b/parser/include/ruby_parser/token.hh
@@ -10,6 +10,8 @@
 #define RUBY_PARSER_TOKEN_TYPES(XX) \
   XX(eof,                     0) \
   XX(error,                  -1) \
+  XX(modePROGRAM,             1) \
+  XX(modePROTOTYPE,           2) \
   XX(kCLASS,               1001) \
   XX(kMODULE,              1002) \
   XX(kDEF,                 1003) \

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -483,7 +483,6 @@ impl Node {
 pub struct Ast {
     pub node: Option<Rc<Node>>,
     pub diagnostics: Vec<Diagnostic>,
-    pub comments: Vec<Comment>,
 }
 
 fn line_map_from_source(source: &str) -> Vec<usize> {

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -71,6 +71,12 @@ pub struct Diagnostic {
     pub data: Option<String>,
 }
 
+#[derive(Debug)]
+pub struct Comment {
+    pub loc: Loc,
+    pub contents: String,
+}
+
 include!(concat!(env!("OUT_DIR"), "/ffi_diagnostics.rs"));
 
 impl fmt::Display for Loc {
@@ -439,6 +445,7 @@ impl Node {
 pub struct Ast {
     pub node: Option<Rc<Node>>,
     pub diagnostics: Vec<Diagnostic>,
+    pub comments: Vec<Comment>,
 }
 
 fn line_map_from_source(source: &str) -> Vec<usize> {

--- a/parser/src/builder.rs
+++ b/parser/src/builder.rs
@@ -12,7 +12,7 @@ use parser::{ParserOptions, ParserMode};
 use onig::Regex as OnigRegex;
 
 lazy_static! {
-    static ref COMMENT_ANNO_RE: Regex = Regex::new(r"^(#\s*@typedruby:?\s*)(.*)$").unwrap();
+    static ref COMMENT_ANNO_RE: Regex = Regex::new(r"^(#\s*@typedruby:\s*)(.*)$").unwrap();
 }
 
 pub struct Builder<'a, 'd: 'a> {

--- a/parser/src/builder.rs
+++ b/parser/src/builder.rs
@@ -7,8 +7,8 @@ use id_arena::IdArena;
 #[cfg(feature = "regex")]
 use onig::Regex;
 
-pub struct Builder<'a> {
-    pub driver: &'a mut Driver,
+pub struct Builder<'a, 'd: 'a> {
+    pub driver: &'a mut Driver<'d>,
     pub magic_literals: bool,
     pub emit_lambda: bool,
     pub emit_procarg0: bool,
@@ -189,7 +189,7 @@ fn call_type_for_dot(dot: Option<Token>) -> CallType {
     }
 }
 
-impl<'a> Builder<'a> {
+impl<'a, 'd> Builder<'a, 'd> {
     /*
      * Helpers
      */

--- a/parser/src/builder.rs
+++ b/parser/src/builder.rs
@@ -1,6 +1,6 @@
 use ffi::{Token, Driver};
 use std::rc::Rc;
-use ast::{Node, Id, Loc, SourceFile, RubyString, Error};
+use ast::{Node, Id, Loc, SourceRef, RubyString, Error};
 use std::collections::HashSet;
 use id_arena::IdArena;
 
@@ -194,12 +194,14 @@ impl<'a, 'd> Builder<'a, 'd> {
      * Helpers
      */
     fn loc(&self, tok: &Option<Token>) -> Loc {
-        tok.as_ref().unwrap().location(self.current_file())
+        let tok = tok.as_ref().unwrap();
+
+        self.source_ref().make_loc(tok.begin_pos(), tok.end_pos())
     }
 
     fn tok_split(&self, tok: &Option<Token>) -> (Loc, RubyString) {
         let tok = tok.as_ref().unwrap();
-        let loc = tok.location(self.current_file());
+        let loc = self.source_ref().make_loc(tok.begin_pos(), tok.end_pos());
         let s = RubyString::new(tok.bytes().as_slice());
         (loc, s)
     }
@@ -213,8 +215,8 @@ impl<'a, 'd> Builder<'a, 'd> {
         self.loc(left).join(&self.loc(right))
     }
 
-    fn current_file(&self) -> Rc<SourceFile> {
-        self.driver.current_file.clone()
+    fn source_ref(&self) -> &SourceRef {
+        &self.driver.source_ref
     }
 
     fn collection_map(&self, begin: Option<Token>, elements: &[Rc<Node>], end: Option<Token>) -> Option<Loc> {

--- a/parser/src/builder.rs
+++ b/parser/src/builder.rs
@@ -4,8 +4,8 @@ use ast::{Node, Id, Loc, SourceFile, RubyString, Error};
 use std::collections::HashSet;
 use id_arena::IdArena;
 
-#[cfg(feature = "regex")]
-use onig::Regex;
+#[cfg(feature = "ruby_regexp")]
+use onig::Regex as OnigRegex;
 
 pub struct Builder<'a, 'd: 'a> {
     pub driver: &'a mut Driver<'d>,
@@ -283,11 +283,11 @@ impl<'a, 'd> Builder<'a, 'd> {
     /*
      * Oniguruma methods (ENABLED)
      */
-    #[cfg(feature = "regex")]
-    fn parse_static_regexp(&mut self, loc: &Loc, parts: &[Rc<Node>]) -> Option<Regex> {
+    #[cfg(feature = "ruby_regexp")]
+    fn parse_static_regexp(&mut self, loc: &Loc, parts: &[Rc<Node>]) -> Option<OnigRegex> {
         let mut st = String::new();
         if build_static_string(&mut st, parts) {
-            match Regex::new(&st) {
+            match OnigRegex::new(&st) {
                 Ok(re) => Some(re),
                 Err(err) => {
                     self.driver.error_with_data(
@@ -300,7 +300,7 @@ impl<'a, 'd> Builder<'a, 'd> {
         }
     }
 
-    #[cfg(feature = "regex")]
+    #[cfg(feature = "ruby_regexp")]
     fn declare_static_regexp(&mut self, node: &Node) -> bool {
         if let &Node::Regexp(ref loc, ref parts, _) = node {
             match self.parse_static_regexp(loc, parts) {
@@ -317,7 +317,7 @@ impl<'a, 'd> Builder<'a, 'd> {
         }
     }
 
-    #[cfg(feature = "regex")]
+    #[cfg(feature = "ruby_regexp")]
     fn check_static_regexp(&mut self, loc: &Loc, parts: &[Rc<Node>]) -> bool {
         self.parse_static_regexp(loc, parts).is_some()
     }
@@ -325,12 +325,12 @@ impl<'a, 'd> Builder<'a, 'd> {
     /*
      * Oniguruma methods (DISABLED)
      */
-    #[cfg(not(feature = "regex"))]
+    #[cfg(not(feature = "ruby_regexp"))]
     fn check_static_regexp(&mut self, _: &Loc, _: &[Rc<Node>]) -> bool {
         true
     }
 
-    #[cfg(not(feature = "regex"))]
+    #[cfg(not(feature = "ruby_regexp"))]
     fn declare_static_regexp(&mut self, node: &Node) -> bool {
         if let &Node::Regexp(_, ref parts, _) = node {
             let mut st = Vec::new();

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "regex")]
+#[cfg(feature = "ruby_regexp")]
 extern crate onig;
 
 mod ast;

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -8,5 +8,5 @@ mod sexp;
 mod builder;
 mod id_arena;
 
-pub use ast::{Ast, SourceFile, Id, Node, Loc, Diagnostic, Level, Error};
+pub use ast::{Ast, SourceFile, Id, Node, Loc, Diagnostic, Level, Error, Comment};
 pub use parser::{parse, parse_with_opts, ParserOptions};

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -1,6 +1,11 @@
 #[cfg(feature = "ruby_regexp")]
 extern crate onig;
 
+#[macro_use]
+extern crate lazy_static;
+
+extern crate regex;
+
 mod ast;
 mod ffi;
 mod parser;
@@ -8,5 +13,5 @@ mod sexp;
 mod builder;
 mod id_arena;
 
-pub use ast::{Ast, SourceFile, Id, Node, Loc, Diagnostic, Level, Error, Comment};
-pub use parser::{parse, parse_with_opts, ParserOptions};
+pub use ast::{Ast, SourceFile, SourceRef, Id, Node, Loc, Diagnostic, Level, Error, Comment};
+pub use parser::{parse, parse_with_opts, ParserOptions, ParserMode};

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -2,11 +2,18 @@ use ast::*;
 use ffi::Driver;
 use std::rc::Rc;
 
+#[derive(Copy,Clone)]
+pub enum ParserMode {
+    Program,
+    Prototype,
+}
+
 pub struct ParserOptions<'a> {
     pub emit_file_vars_as_literals: bool,
     pub emit_lambda: bool,
     pub emit_procarg0: bool,
     pub declare_env: &'a [&'a str],
+    pub mode: ParserMode,
 }
 
 impl<'a> ParserOptions<'a> {
@@ -16,17 +23,18 @@ impl<'a> ParserOptions<'a> {
             emit_lambda: true,
             emit_procarg0: true,
             declare_env: &[],
+            mode: ParserMode::Program,
         }
     }
 }
 
 pub fn parse(source_file: Rc<SourceFile>) -> Ast {
-    parse_with_opts(source_file, &ParserOptions::defaults())
+    parse_with_opts(source_file, ParserOptions::defaults())
 }
 
-pub fn parse_with_opts(source_file: Rc<SourceFile>, opts: &ParserOptions) -> Ast {
-    let mut driver = Driver::new(source_file.clone());
-    let node = driver.parse(&opts);
+pub fn parse_with_opts(source_file: Rc<SourceFile>, opts: ParserOptions) -> Ast {
+    let mut driver = Driver::new(opts, source_file);
+    let node = driver.parse();
 
     Ast {
         node: node,

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -31,5 +31,6 @@ pub fn parse_with_opts(source_file: Rc<SourceFile>, opts: &ParserOptions) -> Ast
     Ast {
         node: node,
         diagnostics: driver.diagnostics(),
+        comments: driver.comments(),
     }
 }

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -29,10 +29,10 @@ impl<'a> ParserOptions<'a> {
 }
 
 pub fn parse(source_file: Rc<SourceFile>) -> Ast {
-    parse_with_opts(source_file, ParserOptions::defaults())
+    parse_with_opts(SourceRef::Entire { file: source_file }, ParserOptions::defaults())
 }
 
-pub fn parse_with_opts(source_file: Rc<SourceFile>, opts: ParserOptions) -> Ast {
+pub fn parse_with_opts(source_file: SourceRef, opts: ParserOptions) -> Ast {
     let mut driver = Driver::new(opts, source_file);
     let node = driver.parse();
 

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -39,6 +39,5 @@ pub fn parse_with_opts(source_file: SourceRef, opts: ParserOptions) -> Ast {
     Ast {
         node: node,
         diagnostics: driver.diagnostics(),
-        comments: driver.comments(),
     }
 }

--- a/parser/tests/fixtures/comment_annotation.rb
+++ b/parser/tests/fixtures/comment_annotation.rb
@@ -1,0 +1,12 @@
+def untyped
+  123
+end
+
+# @typedruby: (Integer x, String y) => ~[String]
+def comment_anno
+  nil
+end
+
+def typed(String x, Integer y) => ~[Integer]
+  nil
+end

--- a/parser/tests/helpers.rs
+++ b/parser/tests/helpers.rs
@@ -34,7 +34,7 @@ mod helpers {
             let code = $code;
             let src = Rc::new(ruby_parser::SourceFile::new(
                     PathBuf::from("(assert_diagnostics)"), code.to_owned()));
-            let ast = ruby_parser::parse_with_opts(src, &$opts);
+            let ast = ruby_parser::parse_with_opts(ruby_parser::SourceRef::Entire { file: src }, $opts);
             assert_eq!(ast.diagnostics.len(), 1);
 
             let err = ast.diagnostics.first().unwrap();
@@ -50,7 +50,7 @@ mod helpers {
             let sexp = $sexp.trim();
             let src = Rc::new(ruby_parser::SourceFile::new(
                     PathBuf::from("(assert_parses)"), code.to_owned()));
-            let ast = ruby_parser::parse_with_opts(src, &$opts);
+            let ast = ruby_parser::parse_with_opts(ruby_parser::SourceRef::Entire { file: src }, $opts);
 
             let mut buf = String::new();
             ast.to_sexp(&mut buf).expect("failed to write sexp output");

--- a/parser/tests/whitequark.rs
+++ b/parser/tests/whitequark.rs
@@ -4690,7 +4690,7 @@ fn parse_const_unscoped() {
 }
 
 #[test]
-#[cfg(feature = "regex")]
+#[cfg(feature = "ruby_regexp")]
 fn parse_lvar_injecting_match() {
 	let code = "/(?<match>bar)/ =~ 'bar'; match";
 	let sexp = r##"

--- a/parser/tests/whitequark.rs
+++ b/parser/tests/whitequark.rs
@@ -13,7 +13,8 @@ ruby_parser::ParserOptions {
   emit_file_vars_as_literals: true,
   emit_lambda: true,
   emit_procarg0: true,
-  declare_env: &["foo", "bar", "baz"]
+  declare_env: &["foo", "bar", "baz"],
+  mode: ruby_parser::ParserMode::Program,
 };
 
 
@@ -3287,7 +3288,8 @@ fn parse_send_lambda_legacy() {
     emit_file_vars_as_literals: true,
     emit_lambda: false,
     emit_procarg0: true,
-    declare_env: &["foo", "bar", "baz"]
+    declare_env: &["foo", "bar", "baz"],
+    mode: ruby_parser::ParserMode::Program,
   };
   let code = "->{ }";
 	let sexp = r##"
@@ -4078,7 +4080,8 @@ fn assert_parses_blockargs_5() {
     emit_file_vars_as_literals: true,
     emit_lambda: true,
     emit_procarg0: false,
-    declare_env: &["foo", "bar", "baz"]
+    declare_env: &["foo", "bar", "baz"],
+    mode: ruby_parser::ParserMode::Program,
   };
 	let code = "f{ |a| }";
 	let sexp = r##"

--- a/parser/tests/whitequark_diags.rs
+++ b/parser/tests/whitequark_diags.rs
@@ -17,449 +17,449 @@ ruby_parser::ParserOptions {
 
 #[test]
 fn diag_send_plain_cmd_ambiguous_prefix() {
-	let code = "m +foo";
-	assert_diag!(code, Level::Warning, Error::AmbiguousPrefix, OPTIONS);
+    let code = "m +foo";
+    assert_diag!(code, Level::Warning, Error::AmbiguousPrefix, OPTIONS);
 }
 
 #[test]
 fn diag_send_plain_cmd_ambiguous_prefix_1() {
-	let code = "m -foo";
-	assert_diag!(code, Level::Warning, Error::AmbiguousPrefix, OPTIONS);
+    let code = "m -foo";
+    assert_diag!(code, Level::Warning, Error::AmbiguousPrefix, OPTIONS);
 }
 
 #[test]
 fn diag_send_plain_cmd_ambiguous_prefix_2() {
-	let code = "m &foo";
-	assert_diag!(code, Level::Warning, Error::AmbiguousPrefix, OPTIONS);
+    let code = "m &foo";
+    assert_diag!(code, Level::Warning, Error::AmbiguousPrefix, OPTIONS);
 }
 
 #[test]
 fn diag_send_plain_cmd_ambiguous_prefix_3() {
-	let code = "m *foo";
-	assert_diag!(code, Level::Warning, Error::AmbiguousPrefix, OPTIONS);
+    let code = "m *foo";
+    assert_diag!(code, Level::Warning, Error::AmbiguousPrefix, OPTIONS);
 }
 
 #[test]
 fn diag_send_plain_cmd_ambiguous_prefix_4() {
-	let code = "m **foo";
-	assert_diag!(code, Level::Warning, Error::AmbiguousPrefix, OPTIONS);
+    let code = "m **foo";
+    assert_diag!(code, Level::Warning, Error::AmbiguousPrefix, OPTIONS);
 }
 
 #[test]
 fn diag_codepoint_too_large() {
-	let code = "\"\\u{120 120000}\"";
-	assert_diag!(code, Level::Error, Error::UnicodePointTooLarge, OPTIONS);
+    let code = "\"\\u{120 120000}\"";
+    assert_diag!(code, Level::Error, Error::UnicodePointTooLarge, OPTIONS);
 }
 
 #[test]
 fn diag_defs_invalid() {
-	let code = "def (1).foo; end";
-	assert_diag!(code, Level::Error, Error::SingletonLiteral, OPTIONS);
+    let code = "def (1).foo; end";
+    assert_diag!(code, Level::Error, Error::SingletonLiteral, OPTIONS);
 }
 
 #[test]
 fn diag_defs_invalid_1() {
-	let code = "def (\"foo\").foo; end";
-	assert_diag!(code, Level::Error, Error::SingletonLiteral, OPTIONS);
+    let code = "def (\"foo\").foo; end";
+    assert_diag!(code, Level::Error, Error::SingletonLiteral, OPTIONS);
 }
 
 #[test]
 fn diag_defs_invalid_2() {
-	let code = "def (\"foo#{bar}\").foo; end";
-	assert_diag!(code, Level::Error, Error::SingletonLiteral, OPTIONS);
+    let code = "def (\"foo#{bar}\").foo; end";
+    assert_diag!(code, Level::Error, Error::SingletonLiteral, OPTIONS);
 }
 
 #[test]
 fn diag_defs_invalid_3() {
-	let code = "def (:foo).foo; end";
-	assert_diag!(code, Level::Error, Error::SingletonLiteral, OPTIONS);
+    let code = "def (:foo).foo; end";
+    assert_diag!(code, Level::Error, Error::SingletonLiteral, OPTIONS);
 }
 
 #[test]
 fn diag_defs_invalid_4() {
-	let code = "def (:\"foo#{bar}\").foo; end";
-	assert_diag!(code, Level::Error, Error::SingletonLiteral, OPTIONS);
+    let code = "def (:\"foo#{bar}\").foo; end";
+    assert_diag!(code, Level::Error, Error::SingletonLiteral, OPTIONS);
 }
 
 #[test]
 fn diag_defs_invalid_5() {
-	let code = "def ([]).foo; end";
-	assert_diag!(code, Level::Error, Error::SingletonLiteral, OPTIONS);
+    let code = "def ([]).foo; end";
+    assert_diag!(code, Level::Error, Error::SingletonLiteral, OPTIONS);
 }
 
 #[test]
 fn diag_defs_invalid_6() {
-	let code = "def ({}).foo; end";
-	assert_diag!(code, Level::Error, Error::SingletonLiteral, OPTIONS);
+    let code = "def ({}).foo; end";
+    assert_diag!(code, Level::Error, Error::SingletonLiteral, OPTIONS);
 }
 
 #[test]
 fn diag_defs_invalid_7() {
-	let code = "def (/foo/).foo; end";
-	assert_diag!(code, Level::Error, Error::SingletonLiteral, OPTIONS);
+    let code = "def (/foo/).foo; end";
+    assert_diag!(code, Level::Error, Error::SingletonLiteral, OPTIONS);
 }
 
 #[test]
 fn diag_asgn_keyword_invalid() {
-	let code = "nil = foo";
-	assert_diag!(code, Level::Error, Error::InvalidAssignment, OPTIONS);
+    let code = "nil = foo";
+    assert_diag!(code, Level::Error, Error::InvalidAssignment, OPTIONS);
 }
 
 #[test]
 fn diag_asgn_keyword_invalid_1() {
-	let code = "self = foo";
-	assert_diag!(code, Level::Error, Error::InvalidAssignment, OPTIONS);
+    let code = "self = foo";
+    assert_diag!(code, Level::Error, Error::InvalidAssignment, OPTIONS);
 }
 
 #[test]
 fn diag_asgn_keyword_invalid_2() {
-	let code = "true = foo";
-	assert_diag!(code, Level::Error, Error::InvalidAssignment, OPTIONS);
+    let code = "true = foo";
+    assert_diag!(code, Level::Error, Error::InvalidAssignment, OPTIONS);
 }
 
 #[test]
 fn diag_asgn_keyword_invalid_3() {
-	let code = "false = foo";
-	assert_diag!(code, Level::Error, Error::InvalidAssignment, OPTIONS);
+    let code = "false = foo";
+    assert_diag!(code, Level::Error, Error::InvalidAssignment, OPTIONS);
 }
 
 #[test]
 fn diag_asgn_keyword_invalid_4() {
-	let code = "__FILE__ = foo";
-	assert_diag!(code, Level::Error, Error::InvalidAssignment, OPTIONS);
+    let code = "__FILE__ = foo";
+    assert_diag!(code, Level::Error, Error::InvalidAssignment, OPTIONS);
 }
 
 #[test]
 fn diag_asgn_keyword_invalid_5() {
-	let code = "__LINE__ = foo";
-	assert_diag!(code, Level::Error, Error::InvalidAssignment, OPTIONS);
+    let code = "__LINE__ = foo";
+    assert_diag!(code, Level::Error, Error::InvalidAssignment, OPTIONS);
 }
 
 #[test]
 fn diag_cpath_invalid() {
-	let code = "module foo; end";
-	assert_diag!(code, Level::Error, Error::ModuleNameConst, OPTIONS);
+    let code = "module foo; end";
+    assert_diag!(code, Level::Error, Error::ModuleNameConst, OPTIONS);
 }
 
 #[test]
 fn diag_rescue_else_useless() {
-	let code = "begin; 1; else; 2; end";
-	assert_diag!(code, Level::Warning, Error::UselessElse, OPTIONS);
+    let code = "begin; 1; else; 2; end";
+    assert_diag!(code, Level::Warning, Error::UselessElse, OPTIONS);
 }
 
 #[test]
 fn diag_arg_duplicate() {
-	let code = "def foo(aa, aa); end";
-	assert_diag!(code, Level::Error, Error::DuplicateArgument, OPTIONS);
+    let code = "def foo(aa, aa); end";
+    assert_diag!(code, Level::Error, Error::DuplicateArgument, OPTIONS);
 }
 
 #[test]
 fn diag_arg_duplicate_1() {
-	let code = "def foo(aa, aa=1); end";
-	assert_diag!(code, Level::Error, Error::DuplicateArgument, OPTIONS);
+    let code = "def foo(aa, aa=1); end";
+    assert_diag!(code, Level::Error, Error::DuplicateArgument, OPTIONS);
 }
 
 #[test]
 fn diag_arg_duplicate_2() {
-	let code = "def foo(aa, *aa); end";
-	assert_diag!(code, Level::Error, Error::DuplicateArgument, OPTIONS);
+    let code = "def foo(aa, *aa); end";
+    assert_diag!(code, Level::Error, Error::DuplicateArgument, OPTIONS);
 }
 
 #[test]
 fn diag_arg_duplicate_3() {
-	let code = "def foo(aa, &aa); end";
-	assert_diag!(code, Level::Error, Error::DuplicateArgument, OPTIONS);
+    let code = "def foo(aa, &aa); end";
+    assert_diag!(code, Level::Error, Error::DuplicateArgument, OPTIONS);
 }
 
 #[test]
 fn diag_arg_duplicate_4() {
-	let code = "def foo(aa, (bb, aa)); end";
-	assert_diag!(code, Level::Error, Error::DuplicateArgument, OPTIONS);
+    let code = "def foo(aa, (bb, aa)); end";
+    assert_diag!(code, Level::Error, Error::DuplicateArgument, OPTIONS);
 }
 
 #[test]
 fn diag_arg_duplicate_5() {
-	let code = "def foo(aa, *r, aa); end";
-	assert_diag!(code, Level::Error, Error::DuplicateArgument, OPTIONS);
+    let code = "def foo(aa, *r, aa); end";
+    assert_diag!(code, Level::Error, Error::DuplicateArgument, OPTIONS);
 }
 
 #[test]
 fn diag_arg_duplicate_6() {
-	let code = "lambda do |aa; aa| end";
-	assert_diag!(code, Level::Error, Error::DuplicateArgument, OPTIONS);
+    let code = "lambda do |aa; aa| end";
+    assert_diag!(code, Level::Error, Error::DuplicateArgument, OPTIONS);
 }
 
 #[test]
 fn diag_arg_duplicate_7() {
-	let code = "def foo(aa, aa: 1); end";
-	assert_diag!(code, Level::Error, Error::DuplicateArgument, OPTIONS);
+    let code = "def foo(aa, aa: 1); end";
+    assert_diag!(code, Level::Error, Error::DuplicateArgument, OPTIONS);
 }
 
 #[test]
 fn diag_arg_duplicate_8() {
-	let code = "def foo(aa, **aa); end";
-	assert_diag!(code, Level::Error, Error::DuplicateArgument, OPTIONS);
+    let code = "def foo(aa, **aa); end";
+    assert_diag!(code, Level::Error, Error::DuplicateArgument, OPTIONS);
 }
 
 #[test]
 fn diag_arg_duplicate_9() {
-	let code = "def foo(aa, aa:); end";
-	assert_diag!(code, Level::Error, Error::DuplicateArgument, OPTIONS);
+    let code = "def foo(aa, aa:); end";
+    assert_diag!(code, Level::Error, Error::DuplicateArgument, OPTIONS);
 }
 
 #[test]
 fn diag_op_asgn_invalid() {
-	let code = "$1 |= 1";
-	assert_diag!(code, Level::Error, Error::BackrefAssignment, OPTIONS);
+    let code = "$1 |= 1";
+    assert_diag!(code, Level::Error, Error::BackrefAssignment, OPTIONS);
 }
 
 #[test]
 fn diag_op_asgn_invalid_1() {
-	let code = "$+ |= 1";
-	assert_diag!(code, Level::Error, Error::BackrefAssignment, OPTIONS);
+    let code = "$+ |= 1";
+    assert_diag!(code, Level::Error, Error::BackrefAssignment, OPTIONS);
 }
 
 #[test]
 fn diag_op_asgn_invalid_2() {
-	let code = "$+ |= m foo";
-	assert_diag!(code, Level::Error, Error::BackrefAssignment, OPTIONS);
+    let code = "$+ |= m foo";
+    assert_diag!(code, Level::Error, Error::BackrefAssignment, OPTIONS);
 }
 
 #[test]
 fn diag_masgn_const_invalid() {
-	let code = "def f; self::A, foo = foo; end";
-	assert_diag!(code, Level::Error, Error::DynamicConst, OPTIONS);
+    let code = "def f; self::A, foo = foo; end";
+    assert_diag!(code, Level::Error, Error::DynamicConst, OPTIONS);
 }
 
 #[test]
 fn diag_masgn_const_invalid_1() {
-	let code = "def f; ::A, foo = foo; end";
-	assert_diag!(code, Level::Error, Error::DynamicConst, OPTIONS);
+    let code = "def f; ::A, foo = foo; end";
+    assert_diag!(code, Level::Error, Error::DynamicConst, OPTIONS);
 }
 
 #[test]
 fn diag_on_error() {
-	let code = "def foo(bar baz); end";
-	assert_diag!(code, Level::Error, Error::UnexpectedToken, OPTIONS);
+    let code = "def foo(bar baz); end";
+    assert_diag!(code, Level::Error, Error::UnexpectedToken, OPTIONS);
 }
 
 #[test]
 fn diag_module_invalid() {
-	let code = "def a; module Foo; end; end";
-	assert_diag!(code, Level::Error, Error::ModuleInDef, OPTIONS);
+    let code = "def a; module Foo; end; end";
+    assert_diag!(code, Level::Error, Error::ModuleInDef, OPTIONS);
 }
 
 #[test]
 fn diag_preexe_invalid() {
-	let code = "def f; BEGIN{}; end";
-	assert_diag!(code, Level::Error, Error::BeginInMethod, OPTIONS);
+    let code = "def f; BEGIN{}; end";
+    assert_diag!(code, Level::Error, Error::BeginInMethod, OPTIONS);
 }
 
 #[test]
 fn diag_class_invalid() {
-	let code = "def a; class Foo; end; end";
-	assert_diag!(code, Level::Error, Error::ClassInDef, OPTIONS);
+    let code = "def a; class Foo; end; end";
+    assert_diag!(code, Level::Error, Error::ClassInDef, OPTIONS);
 }
 
 #[test]
 fn diag_masgn_keyword_invalid() {
-	let code = "nil, foo = bar";
-	assert_diag!(code, Level::Error, Error::InvalidAssignment, OPTIONS);
+    let code = "nil, foo = bar";
+    assert_diag!(code, Level::Error, Error::InvalidAssignment, OPTIONS);
 }
 
 #[test]
 fn diag_log_asgn_invalid() {
-	let code = "$1 &&= 1";
-	assert_diag!(code, Level::Error, Error::BackrefAssignment, OPTIONS);
+    let code = "$1 &&= 1";
+    assert_diag!(code, Level::Error, Error::BackrefAssignment, OPTIONS);
 }
 
 #[test]
 fn diag_log_asgn_invalid_1() {
-	let code = "$+ ||= 1";
-	assert_diag!(code, Level::Error, Error::BackrefAssignment, OPTIONS);
+    let code = "$+ ||= 1";
+    assert_diag!(code, Level::Error, Error::BackrefAssignment, OPTIONS);
 }
 
 #[test]
 fn diag_ruby_bug_12686() {
-	let code = "f(g rescue nil)";
-	assert_diag!(code, Level::Error, Error::UnexpectedToken, OPTIONS);
+    let code = "f(g rescue nil)";
+    assert_diag!(code, Level::Error, Error::UnexpectedToken, OPTIONS);
 }
 
 #[test]
 fn diag_arg_duplicate_proc() {
-	let code = "proc{|a,a|}";
-	assert_diag!(code, Level::Error, Error::DuplicateArgument, OPTIONS);
+    let code = "proc{|a,a|}";
+    assert_diag!(code, Level::Error, Error::DuplicateArgument, OPTIONS);
 }
 
 #[test]
 fn diag_kwarg_invalid() {
-	let code = "def foo(Abc: 1); end";
-	assert_diag!(code, Level::Error, Error::ArgumentConst, OPTIONS);
+    let code = "def foo(Abc: 1); end";
+    assert_diag!(code, Level::Error, Error::ArgumentConst, OPTIONS);
 }
 
 #[test]
 fn diag_kwarg_invalid_1() {
-	let code = "def foo(Abc:); end";
-	assert_diag!(code, Level::Error, Error::ArgumentConst, OPTIONS);
+    let code = "def foo(Abc:); end";
+    assert_diag!(code, Level::Error, Error::ArgumentConst, OPTIONS);
 }
 
 #[test]
 fn diag_var_op_asgn_keyword_invalid() {
-	let code = "nil += foo";
-	assert_diag!(code, Level::Error, Error::InvalidAssignment, OPTIONS);
+    let code = "nil += foo";
+    assert_diag!(code, Level::Error, Error::InvalidAssignment, OPTIONS);
 }
 
 #[test]
 fn diag_alias_nth_ref() {
-	let code = "alias $a $1";
-	assert_diag!(code, Level::Error, Error::NthRefAlias, OPTIONS);
+    let code = "alias $a $1";
+    assert_diag!(code, Level::Error, Error::NthRefAlias, OPTIONS);
 }
 
 #[test]
 fn diag_masgn_backref_invalid() {
-	let code = "$1, = foo";
-	assert_diag!(code, Level::Error, Error::BackrefAssignment, OPTIONS);
+    let code = "$1, = foo";
+    assert_diag!(code, Level::Error, Error::BackrefAssignment, OPTIONS);
 }
 
 #[test]
 fn diag_casgn_invalid() {
-	let code = "def f; Foo = 1; end";
-	assert_diag!(code, Level::Error, Error::DynamicConst, OPTIONS);
+    let code = "def f; Foo = 1; end";
+    assert_diag!(code, Level::Error, Error::DynamicConst, OPTIONS);
 }
 
 #[test]
 fn diag_casgn_invalid_1() {
-	let code = "def f; Foo::Bar = 1; end";
-	assert_diag!(code, Level::Error, Error::DynamicConst, OPTIONS);
+    let code = "def f; Foo::Bar = 1; end";
+    assert_diag!(code, Level::Error, Error::DynamicConst, OPTIONS);
 }
 
 #[test]
 fn diag_casgn_invalid_2() {
-	let code = "def f; ::Bar = 1; end";
-	assert_diag!(code, Level::Error, Error::DynamicConst, OPTIONS);
+    let code = "def f; ::Bar = 1; end";
+    assert_diag!(code, Level::Error, Error::DynamicConst, OPTIONS);
 }
 
 #[test]
 fn diag_arg_invalid() {
-	let code = "def foo(Abc); end";
-	assert_diag!(code, Level::Error, Error::UnexpectedToken, OPTIONS);
+    let code = "def foo(Abc); end";
+    assert_diag!(code, Level::Error, Error::UnexpectedToken, OPTIONS);
 }
 
 #[test]
 fn diag_arg_invalid_1() {
-	let code = "def foo(@abc); end";
-	assert_diag!(code, Level::Error, Error::ArgumentIvar, OPTIONS);
+    let code = "def foo(@abc); end";
+    assert_diag!(code, Level::Error, Error::ArgumentIvar, OPTIONS);
 }
 
 #[test]
 fn diag_arg_invalid_2() {
-	let code = "def foo($abc); end";
-	assert_diag!(code, Level::Error, Error::ArgumentGvar, OPTIONS);
+    let code = "def foo($abc); end";
+    assert_diag!(code, Level::Error, Error::ArgumentGvar, OPTIONS);
 }
 
 #[test]
 fn diag_arg_invalid_3() {
-	let code = "def foo(@@abc); end";
-	assert_diag!(code, Level::Error, Error::ArgumentCvar, OPTIONS);
+    let code = "def foo(@@abc); end";
+    assert_diag!(code, Level::Error, Error::ArgumentCvar, OPTIONS);
 }
 
 #[test]
 fn diag_unterminated_embedded_doc() {
-	let code = "=begin\nfoo\nend";
-	assert_diag!(code, Level::Fatal, Error::EmbeddedDocument, OPTIONS);
+    let code = "=begin\nfoo\nend";
+    assert_diag!(code, Level::Fatal, Error::EmbeddedDocument, OPTIONS);
 }
 
 #[test]
 fn diag_unterminated_embedded_doc_1() {
-	let code = "=begin\nfoo\nend\n";
-	assert_diag!(code, Level::Fatal, Error::EmbeddedDocument, OPTIONS);
+    let code = "=begin\nfoo\nend\n";
+    assert_diag!(code, Level::Fatal, Error::EmbeddedDocument, OPTIONS);
 }
 
 #[test]
 fn diag_send_plain_cmd_ambiguous_literal() {
-	let code = "m /foo/";
-	assert_diag!(code, Level::Warning, Error::AmbiguousLiteral, OPTIONS);
+    let code = "m /foo/";
+    assert_diag!(code, Level::Warning, Error::AmbiguousLiteral, OPTIONS);
 }
 
 #[test]
 fn diag_yield_block() {
-	let code = "yield foo do end";
-	assert_diag!(code, Level::Error, Error::BlockGivenToYield, OPTIONS);
+    let code = "yield foo do end";
+    assert_diag!(code, Level::Error, Error::BlockGivenToYield, OPTIONS);
 }
 
 #[test]
 fn diag_yield_block_1() {
-	let code = "yield(&foo)";
-	assert_diag!(code, Level::Error, Error::BlockGivenToYield, OPTIONS);
+    let code = "yield(&foo)";
+    assert_diag!(code, Level::Error, Error::BlockGivenToYield, OPTIONS);
 }
 
 /*
 #[test]
 fn diag_bug_ascii_8bit_in_literal() {
-	let code = "\".\\xc3.\"";
-	assert_diag!(code, Level::Error, Error::InvalidEncoding, OPTIONS);
+    let code = "\".\\xc3.\"";
+    assert_diag!(code, Level::Error, Error::InvalidEncoding, OPTIONS);
 }
 
 #[test]
 fn diag_bug_ascii_8bit_in_literal_1() {
-	let code = "%W\"x .\\xc3.\"";
-	assert_diag!(code, Level::Error, Error::InvalidEncoding, OPTIONS);
+    let code = "%W\"x .\\xc3.\"";
+    assert_diag!(code, Level::Error, Error::InvalidEncoding, OPTIONS);
 }
 
 #[test]
 fn diag_bug_ascii_8bit_in_literal_2() {
-	let code = ":\".\\xc3.\"";
-	assert_diag!(code, Level::Error, Error::InvalidEncoding, OPTIONS);
+    let code = ":\".\\xc3.\"";
+    assert_diag!(code, Level::Error, Error::InvalidEncoding, OPTIONS);
 }
 
 #[test]
 fn diag_bug_ascii_8bit_in_literal_3() {
-	let code = "%I\"x .\\xc3.\"";
-	assert_diag!(code, Level::Error, Error::InvalidEncoding, OPTIONS);
+    let code = "%I\"x .\\xc3.\"";
+    assert_diag!(code, Level::Error, Error::InvalidEncoding, OPTIONS);
 }
 
 #[test]
 fn diag_bug_ascii_8bit_in_literal_4() {
-	let code = "?\\xc3";
-	assert_diag!(code, Level::Error, Error::InvalidEncoding, OPTIONS);
+    let code = "?\\xc3";
+    assert_diag!(code, Level::Error, Error::InvalidEncoding, OPTIONS);
 }
 */
 
 #[test]
 fn diag_unknown_percent_str() {
-	let code = "%k[foo]";
-	assert_diag!(code, Level::Error, Error::UnexpectedPercentStr, OPTIONS);
+    let code = "%k[foo]";
+    assert_diag!(code, Level::Error, Error::UnexpectedPercentStr, OPTIONS);
 }
 
 #[test]
 fn diag_asgn_backref_invalid() {
-	let code = "$1 = foo";
-	assert_diag!(code, Level::Error, Error::BackrefAssignment, OPTIONS);
+    let code = "$1 = foo";
+    assert_diag!(code, Level::Error, Error::BackrefAssignment, OPTIONS);
 }
 
 #[test]
-#[cfg(feature = "regex")]
+#[cfg(feature = "ruby_regexp")]
 fn diag_regex_error() {
-	let code = "/?/";
-	assert_diag!(code, Level::Error, Error::InvalidRegexp, OPTIONS);
+    let code = "/?/";
+    assert_diag!(code, Level::Error, Error::InvalidRegexp, OPTIONS);
 }
 
 #[test]
-#[cfg(feature = "regex")]
+#[cfg(feature = "ruby_regexp")]
 fn diag_regex_error_1() {
-	let code = "/#{\"\"}?/";
-	assert_diag!(code, Level::Error, Error::InvalidRegexp, OPTIONS);
+    let code = "/#{\"\"}?/";
+    assert_diag!(code, Level::Error, Error::InvalidRegexp, OPTIONS);
 }
 
 #[test]
 fn diag_send_block_blockarg() {
-	let code = "fun(&bar) do end";
-	assert_diag!(code, Level::Error, Error::BlockAndBlockarg, OPTIONS);
+    let code = "fun(&bar) do end";
+    assert_diag!(code, Level::Error, Error::BlockAndBlockarg, OPTIONS);
 }
 
 #[test]
 fn diag_missing_end() {
-	let code = "def foobar";
-	assert_diag!(code, Level::Error, Error::UnexpectedToken, OPTIONS);
+    let code = "def foobar";
+    assert_diag!(code, Level::Error, Error::UnexpectedToken, OPTIONS);
 }
 

--- a/parser/tests/whitequark_diags.rs
+++ b/parser/tests/whitequark_diags.rs
@@ -12,7 +12,8 @@ ruby_parser::ParserOptions {
   emit_file_vars_as_literals: false,
   emit_lambda: true,
   emit_procarg0: true,
-  declare_env: &["foo", "bar", "baz"]
+  declare_env: &["foo", "bar", "baz"],
+  mode: ruby_parser::ParserMode::Program,
 };
 
 #[test]


### PR DESCRIPTION
This pull request implements comment based type annotations. They're currently only supported on methods, but they can easily be extended to classes as well.

They look something like this:

```ruby
# @typedruby: (String a, Integer b) => ~String
def foo(a, b)
  # do stuff
end
```

This will allow Ruby code to use TypedRuby without having to use our custom VM supporting syntax extensions.