### PR TITLE
uint -> size_t

### DIFF
--- a/parser/cc/lexer.rl
+++ b/parser/cc/lexer.rl
@@ -151,7 +151,7 @@ lexer::lexer(diagnostics_t &diag, ruby_version version, const std::string& sourc
 }
 
 void lexer::check_stack_capacity() {
-    if (stack.size() == (uint)top) {
+    if (stack.size() == (size_t)top) {
     stack.resize(stack.size() * 2);
   }
 }


### PR DESCRIPTION
Quick fix for this error:

```
running: "c++" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "-m64" "-I" "include" "-I" "/Users/charlie/github/typedruby/target/release/build/ruby_parser-6a3e4228c4d0a6de/out" "-std=c++14" "-Wall" "-Wextra" "-Wpedantic" "-Wno-unused-const-variable" "-Wall" "-Wextra" "-o" "/Users/charlie/github/typedruby/target/release/build/ruby_parser-6a3e4228c4d0a6de/out/lexer.o" "-c" "/Users/charlie/github/typedruby/target/release/build/ruby_parser-6a3e4228c4d0a6de/out/lexer.cc"
cargo:warning=cc/lexer.rl:154:26: error: use of undeclared identifier 'uint'; did you mean 'int'?
cargo:warning=    if (stack.size() == (uint)top) {
cargo:warning=                         ^~~~
cargo:warning=                         int
cargo:warning=cc/lexer.rl:154:22: warning: comparison of integers of different signs: 'size_type' (aka 'unsigned long') and 'int' [-Wsign-compare]
cargo:warning=    if (stack.size() == (uint)top) {
cargo:warning=        ~~~~~~~~~~~~ ^  ~~~~~~~~~
cargo:warning=1 warning and 1 error generated.
exit code: 1
```