### PR TITLE
Fix "not a static constant path" error on qualified constants in declarations

### DIFF
--- a/src/top_level.rs
+++ b/src/top_level.rs
@@ -146,14 +146,7 @@ impl<'env, 'object> Eval<'env, 'object> {
         };
 
         let ref_ = if let Node::Const(_, ref base, ref id) = *name {
-            match *base {
-                Some(ref base_node) =>
-                    self.resolve_cpath(base_node).and_then(|constant|
-                        constant.module()
-                            .map(|constant| (constant, id))
-                            .ok_or((base_node, "Not a static class/module"))),
-                None => Ok((self.scope.module, id)),
-            }
+            self.resolve_cbase(base).map(|object| (object, id))
         } else {
             Err((name, "Class name is not a static constant"))
         };

--- a/tests/fixtures/class_def.out
+++ b/tests/fixtures/class_def.out
@@ -1,0 +1,53 @@
+error: Could not match types:
+
+        @ __ROOT__/tests/fixtures/class_def.rb:12
+     12 |  def test1 => nil
+                        ^^^ NilClass, with:
+        @ __ROOT__/tests/fixtures/class_def.rb:13
+     13 |    A.new
+               ^^^ A
+
+        - arising from an attempt to match:
+
+        @ __ROOT__/tests/fixtures/class_def.rb:12
+     12 |  def test1 => nil
+                        ^^^ NilClass, with:
+        @ __ROOT__/tests/fixtures/class_def.rb:13
+     13 |    A.new
+             ^^^^^ A
+
+error: Could not match types:
+
+        @ __ROOT__/tests/fixtures/class_def.rb:16
+     16 |  def test2 => nil
+                        ^^^ NilClass, with:
+        @ __ROOT__/tests/fixtures/class_def.rb:17
+     17 |    B::C.new
+                  ^^^ B::C
+
+        - arising from an attempt to match:
+
+        @ __ROOT__/tests/fixtures/class_def.rb:16
+     16 |  def test2 => nil
+                        ^^^ NilClass, with:
+        @ __ROOT__/tests/fixtures/class_def.rb:17
+     17 |    B::C.new
+             ^^^^^^^^ B::C
+
+error: Could not match types:
+
+        @ __ROOT__/tests/fixtures/class_def.rb:20
+     20 |  def test3 => nil
+                        ^^^ NilClass, with:
+        @ __ROOT__/tests/fixtures/class_def.rb:21
+     21 |    B::C::D.new
+                     ^^^ B::C::D
+
+        - arising from an attempt to match:
+
+        @ __ROOT__/tests/fixtures/class_def.rb:20
+     20 |  def test3 => nil
+                        ^^^ NilClass, with:
+        @ __ROOT__/tests/fixtures/class_def.rb:21
+     21 |    B::C::D.new
+             ^^^^^^^^^^^ B::C::D

--- a/tests/fixtures/class_def.rb
+++ b/tests/fixtures/class_def.rb
@@ -1,0 +1,22 @@
+class A
+end
+
+class ::B
+  class C
+  end
+end
+
+class ::B::C::D
+end
+
+def test1 => nil
+  A.new
+end
+
+def test2 => nil
+  B::C.new
+end
+
+def test3 => nil
+  B::C::D.new
+end


### PR DESCRIPTION
Code like this was previously failing with a "Not a static constant path" error:

```ruby
class ::Foo
end
```

This pull request fixes that