### PR TITLE
Fix load path search in require_dependency

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -209,6 +209,10 @@ impl<'object> Environment<'object> {
         Self::search_paths(file, &self.config.require_paths)
     }
 
+    pub fn search_autoload_path(&self, file: &str) -> Option<PathBuf> {
+        Self::search_paths(file, &self.config.autoload_paths)
+    }
+
     pub fn search_relative_path(&self, file: &str, from: &SourceFile) -> Option<PathBuf> {
         from.filename().parent().and_then(|parent| {
             Self::search_paths(file, &[parent])

--- a/src/top_level.rs
+++ b/src/top_level.rs
@@ -63,8 +63,9 @@ struct DeclRef<'object> {
 }
 
 enum RequireType {
-    LoadPath,
-    Relative,
+    Require,
+    RequireDependency,
+    RequireRelative,
 }
 
 impl<'env, 'object> Eval<'env, 'object> {
@@ -594,8 +595,13 @@ impl<'env, 'object> Eval<'env, 'object> {
 
         if let Some(pathstr) = string.string() {
             let path = match require_type {
-                RequireType::LoadPath => self.env.search_require_path(&pathstr),
-                RequireType::Relative => self.env.search_relative_path(&pathstr, &args[0].loc().file()),
+                RequireType::Require =>
+                    self.env.search_require_path(&pathstr),
+                RequireType::RequireDependency =>
+                    self.env.search_autoload_path(&pathstr).or_else(||
+                        self.env.search_require_path(&pathstr)),
+                RequireType::RequireRelative =>
+                    self.env.search_relative_path(&pathstr, &args[0].loc().file()),
             };
 
             if let Some(path) = path {
@@ -631,10 +637,10 @@ impl<'env, 'object> Eval<'env, 'object> {
         match id.1.as_str() {
             "include" => self.process_module_inclusion(id, self.scope.module, args),
             "extend" => self.process_module_inclusion(id, self.env.object.metaclass(self.scope.module), args),
-            "require" => self.process_require(id, args, RequireType::LoadPath),
+            "require" => self.process_require(id, args, RequireType::Require),
             // TODO guard require_dependency behind a rails-mode flag:
-            "require_dependency" => self.process_require(id, args, RequireType::LoadPath),
-            "require_relative" => self.process_require(id, args, RequireType::Relative),
+            "require_dependency" => self.process_require(id, args, RequireType::RequireDependency),
+            "require_relative" => self.process_require(id, args, RequireType::RequireRelative),
             "alias_method" => self.process_alias_method(id, args),
             "attr_reader" => self.process_attr(AttrType::Reader, args),
             "attr_writer" => self.process_attr(AttrType::Writer, args),


### PR DESCRIPTION
`require_dependency` first searches the Rails autoload path before falling back to the Ruby load path.  The current implementation only searches the Ruby load path.