### PR TITLE
Stub JSON.generate and JSON.parse

### DIFF
--- a/definitions/lib/json.rb
+++ b/definitions/lib/json.rb
@@ -2,7 +2,7 @@ module JSON
   def self.dump(:any object) => String
   end
 
-  def self.generate(:any object, (nil | JSON::State | Hash::[Symbol, :any]) options) => String
+  def self.generate(:any object, (nil | JSON::State | Hash::[Symbol, :any]) options = nil) => String
   end
 
   def self.parse(String json) => :any


### PR DESCRIPTION
I have no idea what I'm doing here.

`JSON.generate` takes the object to generate, as well as "options", which can be a Hash, a `JSON::State`, or `nil`. Sooooo I just said `:any`.

`JSON.parse` always returns a `Hash` where all the keys are Strings 'cuz JSON, but the values can be anything. `nil` is an annoying case here. If `JSON.parse("null")`, you get `nil`. So my gut says a `nil`-able Hash is the only way to go here.