### PR TITLE
Fix a memory error in lexer.rl

### DIFF
--- a/parser/cc/lexer.rl
+++ b/parser/cc/lexer.rl
@@ -1063,7 +1063,7 @@ void lexer::set_state_expr_value() {
     if (current_literal.heredoc()) {
       auto line = tok(herebody_s, ts);
 
-      while (line.back() == '\r') {
+      while (!line.empty() && line.back() == '\r') {
         line.pop_back();
       }
 


### PR DESCRIPTION
This token can be empty, in which case `back()` is invalid. Found by
adding `.flag("-D_GLIBCXX_DEBUG")` to `parser/build.rs` to build with
STL checking.