### PR TITLE
Strip trailing whitespace

### DIFF
--- a/src/strip.rs
+++ b/src/strip.rs
@@ -88,7 +88,7 @@ fn trim_around_range(source: &str, ByteRange(start, end): ByteRange) -> ByteRang
     }
 
     fn line_whitespace(c: char) -> bool {
-        !newline(c) && c.is_whitespace()
+        !newline(c) && (c == ' ' || c == '\t')
     }
 }
 


### PR DESCRIPTION
Currently when we strip source like `def foo => T` we leave behind a trailing space after `foo` (so the resulting source code looks like `"def foo "`).

This pull request strips trailing whitespace around removed byte ranges. It doesn't touch trailing whitespace that isn't adjacent to type annotations in case that trailing whitespace is somehow meaningful.

cc @vmg