### PR TITLE
Perf: Use vector<bool> instead of stack<bool>

### DIFF
--- a/parser/cc/state_stack.cc
+++ b/parser/cc/state_stack.cc
@@ -3,15 +3,15 @@
 using namespace ruby_parser;
 
 void state_stack::push(bool state) {
-  stack.push(state);
+  stack.emplace_back(state);
 }
 
 bool state_stack::pop() {
   if (stack.empty()) {
     return false;
   } else {
-    bool state = stack.top();
-    stack.pop();
+    bool state = stack.back();
+    stack.pop_back();
     return state;
   }
 }
@@ -21,13 +21,14 @@ void state_stack::lexpop() {
 }
 
 void state_stack::clear() {
-  stack = std::stack<bool>();
+  stack.clear();
 }
 
 bool state_stack::active() const {
   if (stack.empty()) {
     return false;
   } else {
-    return stack.top();
+    return stack.back();
   }
 }
+

--- a/parser/include/ruby_parser/state_stack.hh
+++ b/parser/include/ruby_parser/state_stack.hh
@@ -1,12 +1,12 @@
 #ifndef RUBY_PARSER_STATE_STACK_HH
 #define RUBY_PARSER_STATE_STACK_HH
 
-#include <stack>
+#include <vector>
 #include <memory>
 
 namespace ruby_parser {
   class state_stack {
-    std::stack<bool> stack;
+    std::vector<bool> stack;
 
   public:
     void push(bool state);
@@ -18,3 +18,4 @@ namespace ruby_parser {
 }
 
 #endif
+


### PR DESCRIPTION
stack<bool> is implemeted by a deque<bool> which will do
allocation per every operation.
This is very innefficient to store a single bit.

vector<bool> work better in this specific use-case.
This gave ~8% speedup on our internal benchmark.