### PR TITLE
Fix some NULL dereferences in parser destructors

### DIFF
--- a/parser/cc/grammars/typedruby24.ypp
+++ b/parser/cc/grammars/typedruby24.ypp
@@ -360,7 +360,8 @@ using namespace std::string_literals;
   superclass
 
 %destructor {
-  driver.build.free_node(self, $$->nod);
+  if ($$ != nullptr)
+    driver.build.free_node(self, $$->nod);
 } <with_token>
 
 %type <case_body>
@@ -368,9 +369,11 @@ using namespace std::string_literals;
   cases
 
 %destructor {
-  driver.build.free_node_list(self, &$$->whens);
-  if ($$->els)
-    driver.build.free_node(self, $$->els->nod);
+  if ($$ != nullptr) {
+    driver.build.free_node_list(self, &$$->whens);
+    if ($$->els)
+      driver.build.free_node(self, $$->els->nod);
+  }
 } <case_body>
 
 %nonassoc tLOWEST


### PR DESCRIPTION
Found by running libfuzzer over our C++ parser frontend/builder.