### PR TITLE
Remove errant asserts in tuple type compatibility check

### DIFF
--- a/src/typecheck/types.rs
+++ b/src/typecheck/types.rs
@@ -588,10 +588,11 @@ impl<'ty, 'object: 'ty> TypeEnv<'ty, 'object> {
                     to_elems.consume_front();
                 }
 
-                assert!(to_elems.is_empty());
-                assert!(from_elems.is_empty());
-
-                Ok(())
+                if to_elems.is_empty() && from_elems.is_empty() {
+                    Ok(())
+                } else {
+                    Err(TypeError::Incompatible(to, from))
+                }
             }
             (&Type::KeywordHash { .. }, &Type::KeywordHash { .. }) => {
                 panic!("TODO implement compatible for keyword hash to keyword hash");

--- a/tests/fixtures/tuple_type_compatibility.out
+++ b/tests/fixtures/tuple_type_compatibility.out
@@ -1,0 +1,45 @@
+info: Typechecking...
+error: Could not match types:
+
+        @ __ROOT__/tests/fixtures/tuple_type_compatibility.rb:3
+      3 |  def f([Integer, String] x) => nil; end
+                 ^^^^^^^^^^^^^^^^^ [Integer, String], with:
+        @ __ROOT__/tests/fixtures/tuple_type_compatibility.rb:6
+      6 |    f [1]
+               ^^^ [Integer]
+        @ __ROOT__/tests/fixtures/tuple_type_compatibility.rb:6
+      6 |    f [1]
+             ^^^^^ in this expression
+
+error: Could not match types:
+
+        @ __ROOT__/tests/fixtures/tuple_type_compatibility.rb:3
+      3 |  def f([Integer, String] x) => nil; end
+                 ^^^^^^^^^^^^^^^^^ [Integer, String], with:
+        @ __ROOT__/tests/fixtures/tuple_type_compatibility.rb:14
+     14 |    f [1, "foo", :bar]
+               ^^^^^^^^^^^^^^^^ [Integer, String, Symbol]
+        @ __ROOT__/tests/fixtures/tuple_type_compatibility.rb:14
+     14 |    f [1, "foo", :bar]
+             ^^^^^^^^^^^^^^^^^^ in this expression
+
+error: Could not match types:
+
+        @ __ROOT__/tests/fixtures/tuple_type_compatibility.rb:3
+      3 |  def f([Integer, String] x) => nil; end
+                  ^^^^^^^ Integer, with:
+        @ __ROOT__/tests/fixtures/tuple_type_compatibility.rb:18
+     18 |    f ["foo", :bar, 1]
+                ^^^^^ String
+
+        - arising from an attempt to match:
+
+        @ __ROOT__/tests/fixtures/tuple_type_compatibility.rb:3
+      3 |  def f([Integer, String] x) => nil; end
+                 ^^^^^^^^^^^^^^^^^ [Integer, String], with:
+        @ __ROOT__/tests/fixtures/tuple_type_compatibility.rb:18
+     18 |    f ["foo", :bar, 1]
+               ^^^^^^^^^^^^^^^^ [String, Symbol, Integer]
+        @ __ROOT__/tests/fixtures/tuple_type_compatibility.rb:18
+     18 |    f ["foo", :bar, 1]
+             ^^^^^^^^^^^^^^^^^^ in this expression

--- a/tests/fixtures/tuple_type_compatibility.rb
+++ b/tests/fixtures/tuple_type_compatibility.rb
@@ -1,0 +1,19 @@
+# @typedruby
+
+def f([Integer, String] x) => nil; end
+
+def test1 => nil
+  f [1]
+end
+
+def test2 => nil
+  f [1, "foo"]
+end
+
+def test3 => nil
+  f [1, "foo", :bar]
+end
+
+def test4 => nil
+  f ["foo", :bar, 1]
+end


### PR DESCRIPTION
This fixes a silly panic when TypedRuby tries to match a tuple with another of a different length.

Instead, we only return ok if the `to_elems` and `from_elems` vecs are both empty after matching tuple elements.

We have to be quite strict here in not simply ignoring extra elements off the end of the 'from' tuple - if the 'to' tuple is later matched against a tuple with a splat and post elements it could pull unexpected elements out.